### PR TITLE
Drop nbsp in JSON files

### DIFF
--- a/_datasets/json/rdls_lss-wb_sfrarr_earthquake.json
+++ b/_datasets/json/rdls_lss-wb_sfrarr_earthquake.json
@@ -12,7 +12,7 @@
       },
       "version": "2022",
       "purpose": "Regional risk modelling. These data have been derived on a regional scale for the purpose of consistent regional multi-country hazard and risk assessment. Application of this information on smaller scales should be done with care. Importantly on a local scale, it is often the case that more detailed history and hazard information is required to perform such hazard and risk modelling, particularly were applied to dimension mitigation structures or strategies.",
-      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
+      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
       "spatial": {
         "countries": ["KAZ", "KGZ", "TKM", "TJK", "UZB"],
         "bbox": [46, 88, 34, 57],

--- a/_datasets/json/rdls_lss-wb_sfrarr_flood.json
+++ b/_datasets/json/rdls_lss-wb_sfrarr_flood.json
@@ -12,7 +12,7 @@
       },
       "version": "2022",
       "purpose": "Regional risk modelling. These data have been derived on a regional scale for the purpose of consistent regional multi-country hazard and risk assessment. Application of this information on smaller scales should be done with care. Importantly on a local scale, it is often the case that more detailed history and hazard information is required to perform such hazard and risk modelling, particularly were applied to dimension mitigation structures or strategies.",
-      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
+      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
       "spatial": {
         "countries": ["KAZ", "KGZ", "TKM", "TJK", "UZB"],
         "bbox": [46, 88, 34, 57],

--- a/_datasets/json/rdls_vln-wb_sfrarr_earthquake.json
+++ b/_datasets/json/rdls_vln-wb_sfrarr_earthquake.json
@@ -12,7 +12,7 @@
       },
       "version": "2022",
       "purpose": "Regional risk modelling. These data have been derived on a regional scale for the purpose of consistent regional multi-country hazard and risk assessment. Application of this information on smaller scales should be done with care. Importantly on a local scale, it is often the case that more detailed history and hazard information is required to perform such hazard and risk modelling, particularly were applied to dimension mitigation structures or strategies., it is often the case that more detailed history and hazard information is required to perform such hazard and risk modelling, particularly were applied to dimension mitigation structures or strategies",
-      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
+      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
       "spatial": {
         "countries": ["KAZ", "KGZ", "TKM", "TJK", "UZB"],
         "bbox": [46, 88, 34, 57],

--- a/_datasets/json/rdls_vln-wb_sfrarr_flood.json
+++ b/_datasets/json/rdls_vln-wb_sfrarr_flood.json
@@ -12,7 +12,7 @@
       },
       "version": "2022",
       "purpose": "Regional risk modelling. These data have been derived on a regional scale for the purpose of consistent regional multi-country hazard and risk assessment. Application of this information on smaller scales should be done with care. Importantly on a local scale, it is often the case that more detailed history and hazard information is required to perform such hazard and risk modelling, particularly were applied to dimension mitigation structures or strategies., it is often the case that more detailed history and hazard information is required to perform such hazard and risk modelling, particularly were applied to dimension mitigation structures or strategies",
-      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
+      "project": "SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction in Central Asia",
       "spatial": {
         "countries": ["KAZ", "KGZ", "TKM", "TJK", "UZB"],
         "bbox": [46, 88, 34, 57],

--- a/_datasets/rdls_lss-wb_sfrarr_earthquake.md
+++ b/_datasets/rdls_lss-wb_sfrarr_earthquake.md
@@ -40,8 +40,8 @@ loss:
   impact_unit: count
   type: ground_up
   vulnerability_id: CA_SFRARR_EQ_vuln
-project: "SFRARR -\xC2\_Strengthening Financial Resilience and Accelerating Risk Reduction\
-  \ in Central Asia"
+project: SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction
+  in Central Asia
 publisher:
   name: RED - Risk, Engineering  Development - Pavia (Italy)
   url: https://www.redrisk.com

--- a/_datasets/rdls_lss-wb_sfrarr_flood.md
+++ b/_datasets/rdls_lss-wb_sfrarr_flood.md
@@ -42,8 +42,8 @@ loss:
   impact_unit: count
   type: ground_up
   vulnerability_id: CA_SFRARR_FL_vuln
-project: "SFRARR -\xC2\_Strengthening Financial Resilience and Accelerating Risk Reduction\
-  \ in Central Asia"
+project: SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction
+  in Central Asia
 publisher:
   name: RED - Risk, Engineering  Development - Pavia (Italy)
   url: https://www.redrisk.com

--- a/_datasets/rdls_vln-wb_sfrarr_earthquake.md
+++ b/_datasets/rdls_vln-wb_sfrarr_earthquake.md
@@ -16,8 +16,8 @@ exposure: null
 hazard: null
 license: CC-BY-SA-4.0
 loss: null
-project: "SFRARR -\xC2\_Strengthening Financial Resilience and Accelerating Risk Reduction\
-  \ in Central Asia"
+project: SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction
+  in Central Asia
 publisher:
   name: RED - Risk, Engineering  Development - Pavia (Italy)
   url: https://www.redrisk.com

--- a/_datasets/rdls_vln-wb_sfrarr_flood.md
+++ b/_datasets/rdls_vln-wb_sfrarr_flood.md
@@ -21,8 +21,8 @@ exposure: null
 hazard: null
 license: CC-BY-SA-4.0
 loss: null
-project: "SFRARR -\xC2\_Strengthening Financial Resilience and Accelerating Risk Reduction\
-  \ in Central Asia"
+project: SFRARR - Strengthening Financial Resilience and Accelerating Risk Reduction
+  in Central Asia
 publisher:
   name: RED - Risk, Engineering  Development - Pavia (Italy)
   url: https://www.redrisk.com


### PR DESCRIPTION
There are some invisible non-breaking space characters that rendered as "Â" and needed to be stripped out.