### PR TITLE
Test upload Loss (only) metadata from DesInventar - HDX

### DIFF
--- a/_datasets/json/rdls_lss-albundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-albundrr_desinventar.json
@@ -1,0 +1,2027 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-albundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Albania",
+      "description": "National disaster loss inventory for Albania from the DesInventar Sendai Framework Monitor database, compiled by General Directorate of Civil Emergencies and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 4,659 event-level loss records covering 1973-2015, with observed impacts from coastal_flood, convective_storm, drought, earthquake, extreme_temperature, flood, landslide, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Albania from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Albania, maintained by General Directorate of Civil Emergencies. Covers 4,659 observed disaster events from 1973-2015. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "ALB"
+        ],
+        "bbox": [
+          19.27,
+          39.64,
+          21.04,
+          42.65
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Albania",
+            "uri": "https://www.geonames.org/783754/albania.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "General Directorate of Civil Emergencies",
+            "url": "More information can be found here: http://www.mbrojtjacivile.al/"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Albania maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Albania",
+          "url": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Albania",
+          "description": "Disaster data for Albania",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e/resource/6850c4bf-cceb-4975-8716-8a5108ad82c3/download/albania.zip",
+          "access_url": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster Tabular data for Albania",
+          "description": "Disaster Tabular data for Albania",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e/resource/0d9d729f-658c-4e7d-bbf7-f2558e8a9715/download/di_report-albania.xls",
+          "access_url": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_coastalflood_houses_damaged",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from coastal flood (SURGE) events in Albania. DesInventar records: 2 events with data out of 7 total coastal flood events (1975-2012)."
+          },
+          {
+            "id": "loss_002_convectivestorm_damages_in_crops_ha",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 79 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_003_convectivestorm_deaths",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 54 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_004_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 2 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_005_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 2 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_006_convectivestorm_injured",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 19 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_007_convectivestorm_losses_local",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 20 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_008_convectivestorm_lost_cattle",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 18 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_009_convectivestorm_victims",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from convective storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 1 events with data out of 217 total convective storm events (1976-2014)."
+          },
+          {
+            "id": "loss_010_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Albania. DesInventar records: 1 events with data out of 1 total drought events (1993-1993)."
+          },
+          {
+            "id": "loss_011_earthquake_affected",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 8 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_012_earthquake_damages_in_roads_mts",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 1 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_013_earthquake_deaths",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 14 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_014_earthquake_education_centers",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 8 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_015_earthquake_evacuated",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 5 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_016_earthquake_hospitals",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 5 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_017_earthquake_houses_damaged",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 92 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_018_earthquake_houses_destroyed",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 66 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_019_earthquake_injured",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 18 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_020_earthquake_losses_local",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 78 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_021_earthquake_victims",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 26 events with data out of 185 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_022_earthquake_victims",
+            "hazard_type": "earthquake",
+            "hazard_process": "liquefaction",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from earthquake (LIQUEFACTION) events in Albania. DesInventar records: 2 events with data out of 4 total earthquake events (2014-2014)."
+          },
+          {
+            "id": "loss_023_extremetemperature_damages_in_crops_ha",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 55 events with data out of 126 total extreme temperature events (1990-2012)."
+          },
+          {
+            "id": "loss_024_extremetemperature_deaths",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 10 events with data out of 126 total extreme temperature events (1990-2012)."
+          },
+          {
+            "id": "loss_025_extremetemperature_houses_damaged",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 2 events with data out of 126 total extreme temperature events (1990-2012)."
+          },
+          {
+            "id": "loss_026_extremetemperature_injured",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 10 events with data out of 126 total extreme temperature events (1990-2012)."
+          },
+          {
+            "id": "loss_027_extremetemperature_losses_local",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 5 events with data out of 126 total extreme temperature events (1990-2012)."
+          },
+          {
+            "id": "loss_028_extremetemperature_lost_cattle",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 10 events with data out of 126 total extreme temperature events (1990-2012)."
+          },
+          {
+            "id": "loss_029_extremetemperature_deaths",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_heat",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from extreme temperature (HEAT WAVE) events in Albania. DesInventar records: 9 events with data out of 22 total extreme temperature events (1998-2002)."
+          },
+          {
+            "id": "loss_030_extremetemperature_injured",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_heat",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from extreme temperature (HEAT WAVE) events in Albania. DesInventar records: 11 events with data out of 22 total extreme temperature events (1998-2002)."
+          },
+          {
+            "id": "loss_031_extremetemperature_lost_cattle",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_heat",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from extreme temperature (HEAT WAVE) events in Albania. DesInventar records: 1 events with data out of 22 total extreme temperature events (1998-2002)."
+          },
+          {
+            "id": "loss_032_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 18 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_033_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 474 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_034_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 19 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_035_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 44 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_036_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 13 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_037_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 76 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_038_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 2 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_039_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 208 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_040_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 96 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_041_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 18 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_042_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 225 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_043_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 4 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_044_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 96 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_045_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 1 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_046_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 4 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_047_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 129 events with data out of 949 total flood events (2002-2015)."
+          },
+          {
+            "id": "loss_048_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (RAINS) events in Albania. DesInventar records: 1 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_049_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (RAINS) events in Albania. DesInventar records: 49 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_050_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (RAINS) events in Albania. DesInventar records: 4 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_051_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (RAINS) events in Albania. DesInventar records: 3 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_052_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (RAINS) events in Albania. DesInventar records: 2 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_053_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (RAINS) events in Albania. DesInventar records: 2 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_054_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (RAINS) events in Albania. DesInventar records: 40 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_055_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (RAINS) events in Albania. DesInventar records: 43 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_056_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (RAINS) events in Albania. DesInventar records: 2 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_057_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from flood (RAINS) events in Albania. DesInventar records: 57 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_058_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (RAINS) events in Albania. DesInventar records: 3 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_059_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (RAINS) events in Albania. DesInventar records: 1 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_060_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (RAINS) events in Albania. DesInventar records: 42 events with data out of 217 total flood events (2007-2013)."
+          },
+          {
+            "id": "loss_061_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE) events in Albania. DesInventar records: 5 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_062_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Albania. DesInventar records: 17 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_063_landslide_damages_in_roads_mts",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from landslide (LANDSLIDE) events in Albania. DesInventar records: 30 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_064_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Albania. DesInventar records: 40 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_065_landslide_education_centers",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from landslide (LANDSLIDE) events in Albania. DesInventar records: 7 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_066_landslide_evacuated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from landslide (LANDSLIDE) events in Albania. DesInventar records: 29 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_067_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE) events in Albania. DesInventar records: 117 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_068_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Albania. DesInventar records: 346 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_069_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (LANDSLIDE) events in Albania. DesInventar records: 15 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_070_landslide_losses_local",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from landslide (LANDSLIDE) events in Albania. DesInventar records: 306 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_071_landslide_losses_usd",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from landslide (LANDSLIDE) events in Albania. DesInventar records: 1 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_072_landslide_lost_cattle",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from landslide (LANDSLIDE) events in Albania. DesInventar records: 3 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_073_landslide_relocated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from landslide (LANDSLIDE) events in Albania. DesInventar records: 5 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_074_landslide_victims",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE) events in Albania. DesInventar records: 249 events with data out of 629 total landslide events (1995-2013)."
+          },
+          {
+            "id": "loss_075_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_mudflow",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (SEDIMENTATION) events in Albania. DesInventar records: 2 events with data out of 3 total landslide events (1999-2005)."
+          },
+          {
+            "id": "loss_076_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (AVALANCHE) events in Albania. DesInventar records: 17 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_077_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (AVALANCHE) events in Albania. DesInventar records: 3 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_078_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (AVALANCHE) events in Albania. DesInventar records: 3 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_079_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (AVALANCHE) events in Albania. DesInventar records: 8 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_080_landslide_losses_local",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from landslide (AVALANCHE) events in Albania. DesInventar records: 2 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_081_landslide_lost_cattle",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from landslide (AVALANCHE) events in Albania. DesInventar records: 3 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_082_landslide_missing",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from landslide (AVALANCHE) events in Albania. DesInventar records: 2 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_083_landslide_victims",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from landslide (AVALANCHE) events in Albania. DesInventar records: 1 events with data out of 25 total landslide events (2010-2012)."
+          },
+          {
+            "id": "loss_084_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 55 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_085_strongwind_damages_in_crops_ha",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 50 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_086_strongwind_damages_in_roads_mts",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 4 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_087_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 45 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_088_strongwind_education_centers",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 28 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_089_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 16 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_090_strongwind_hospitals",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 1 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_091_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 86 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_092_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 108 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_093_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 26 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_094_strongwind_losses_local",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 130 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_095_strongwind_lost_cattle",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 65 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_096_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 4 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_097_strongwind_victims",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 88 events with data out of 891 total strong wind events (1973-2012)."
+          },
+          {
+            "id": "loss_098_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 4 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_099_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 716 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_100_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 13 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_101_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 1 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_102_wildfire_evacuated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 5 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_103_wildfire_hospitals",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 1 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_104_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 60 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_105_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 46 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_106_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 6 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_107_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ALL"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 65 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_108_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 23 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_109_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 11 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_110_wildfire_relocated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 5 events with data out of 1,383 total wildfire events (2003-2014)."
+          },
+          {
+            "id": "loss_111_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 37 events with data out of 1,383 total wildfire events (2003-2014)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-colundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-colundrr_desinventar.json
@@ -1,0 +1,2455 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-colundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Colombia",
+      "description": "National disaster loss inventory for Colombia from the DesInventar Sendai Framework Monitor database, compiled by Corporacion OSSO / La Red and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 28,916 event-level loss records covering 1963-2013, with observed impacts from coastal_flood, convective_storm, drought, earthquake, extreme_temperature, flood, landslide, strong_wind, tsunami, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Colombia from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Colombia, maintained by Corporacion OSSO / La Red. Covers 28,916 observed disaster events from 1963-2013. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "COL"
+        ],
+        "bbox": [
+          -81.72,
+          -4.24,
+          -66.88,
+          13.58
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Colombia",
+            "uri": "https://www.geonames.org/3686110/colombia.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Corporacion OSSO / La Red",
+            "url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Colombia maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Colombia",
+          "url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Colombia",
+          "description": "Disaster data for Colombia",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79/resource/93b7528b-46fd-4504-9406-f4d97a59a24c/download/colombia.zip",
+          "access_url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster Tabular data for Colombia",
+          "description": "Disaster Tabular data for Colombia",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79/resource/f156b3b5-97ab-48a5-b66d-5c00d56f85c9/download/di_report-colombia.xls",
+          "access_url": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_coastalflood_affected",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from coastal flood (SURGE) events in Colombia. DesInventar records: 52 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_002_coastalflood_damages_in_crops_ha",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from coastal flood (SURGE) events in Colombia. DesInventar records: 1 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_003_coastalflood_damages_in_roads_mts",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from coastal flood (SURGE) events in Colombia. DesInventar records: 2 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_004_coastalflood_deaths",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from coastal flood (SURGE) events in Colombia. DesInventar records: 18 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_005_coastalflood_education_centers",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from coastal flood (SURGE) events in Colombia. DesInventar records: 2 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_006_coastalflood_evacuated",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from coastal flood (SURGE) events in Colombia. DesInventar records: 8 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_007_coastalflood_hospitals",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from coastal flood (SURGE) events in Colombia. DesInventar records: 1 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_008_coastalflood_houses_damaged",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from coastal flood (SURGE) events in Colombia. DesInventar records: 33 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_009_coastalflood_houses_destroyed",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from coastal flood (SURGE) events in Colombia. DesInventar records: 52 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_010_coastalflood_injured",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from coastal flood (SURGE) events in Colombia. DesInventar records: 4 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_011_coastalflood_losses_local",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from coastal flood (SURGE) events in Colombia. DesInventar records: 8 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_012_coastalflood_missing",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from coastal flood (SURGE) events in Colombia. DesInventar records: 9 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_013_coastalflood_victims",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from coastal flood (SURGE) events in Colombia. DesInventar records: 12 events with data out of 159 total coastal flood events (1984-2013)."
+          },
+          {
+            "id": "loss_014_convectivestorm_affected",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from convective storm (HAILSTORM) events in Colombia. DesInventar records: 39 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_015_convectivestorm_damages_in_crops_ha",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from convective storm (HAILSTORM) events in Colombia. DesInventar records: 6 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_016_convectivestorm_damages_in_roads_mts",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from convective storm (HAILSTORM) events in Colombia. DesInventar records: 1 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_017_convectivestorm_education_centers",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from convective storm (HAILSTORM) events in Colombia. DesInventar records: 4 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_018_convectivestorm_hospitals",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from convective storm (HAILSTORM) events in Colombia. DesInventar records: 2 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_019_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (HAILSTORM) events in Colombia. DesInventar records: 30 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_020_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (HAILSTORM) events in Colombia. DesInventar records: 6 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_021_convectivestorm_injured",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from convective storm (HAILSTORM) events in Colombia. DesInventar records: 2 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_022_convectivestorm_losses_local",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from convective storm (HAILSTORM) events in Colombia. DesInventar records: 11 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_023_convectivestorm_lost_cattle",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from convective storm (HAILSTORM) events in Colombia. DesInventar records: 1 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_024_convectivestorm_victims",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from convective storm (HAILSTORM) events in Colombia. DesInventar records: 4 events with data out of 81 total convective storm events (1989-2013)."
+          },
+          {
+            "id": "loss_025_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Colombia. DesInventar records: 115 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_026_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar records: 25 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_027_drought_education_centers",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar records: 1 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_028_drought_hospitals",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar records: 1 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_029_drought_houses_damaged",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from drought (DROUGHT) events in Colombia. DesInventar records: 2 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_030_drought_losses_local",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from drought (DROUGHT) events in Colombia. DesInventar records: 25 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_031_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (DROUGHT) events in Colombia. DesInventar records: 6 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_032_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (DROUGHT) events in Colombia. DesInventar records: 1 events with data out of 591 total drought events (1985-2012)."
+          },
+          {
+            "id": "loss_033_earthquake_affected",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 211 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_034_earthquake_damages_in_crops_ha",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 1 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_035_earthquake_damages_in_roads_mts",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 19 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_036_earthquake_deaths",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 144 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_037_earthquake_education_centers",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 146 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_038_earthquake_evacuated",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 11 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_039_earthquake_hospitals",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 46 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_040_earthquake_houses_damaged",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 362 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_041_earthquake_houses_destroyed",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 359 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_042_earthquake_injured",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 158 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_043_earthquake_losses_local",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 23 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_044_earthquake_losses_usd",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 2 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_045_earthquake_missing",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 22 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_046_earthquake_victims",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 195 events with data out of 888 total earthquake events (1986-2013)."
+          },
+          {
+            "id": "loss_047_extremetemperature_affected",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from extreme temperature (FROST) events in Colombia. DesInventar records: 6 events with data out of 62 total extreme temperature events (1985-2013)."
+          },
+          {
+            "id": "loss_048_extremetemperature_damages_in_crops_ha",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from extreme temperature (FROST) events in Colombia. DesInventar records: 20 events with data out of 62 total extreme temperature events (1985-2013)."
+          },
+          {
+            "id": "loss_049_extremetemperature_losses_local",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from extreme temperature (FROST) events in Colombia. DesInventar records: 7 events with data out of 62 total extreme temperature events (1985-2013)."
+          },
+          {
+            "id": "loss_050_extremetemperature_lost_cattle",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from extreme temperature (FROST) events in Colombia. DesInventar records: 1 events with data out of 62 total extreme temperature events (1985-2013)."
+          },
+          {
+            "id": "loss_051_extremetemperature_victims",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from extreme temperature (FROST) events in Colombia. DesInventar records: 2 events with data out of 62 total extreme temperature events (1985-2013)."
+          },
+          {
+            "id": "loss_052_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Colombia. DesInventar records: 8,904 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_053_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Colombia. DesInventar records: 1,015 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_054_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (FLOOD) events in Colombia. DesInventar records: 484 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_055_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Colombia. DesInventar records: 756 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_056_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Colombia. DesInventar records: 455 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_057_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD) events in Colombia. DesInventar records: 423 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_058_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Colombia. DesInventar records: 88 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_059_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Colombia. DesInventar records: 5,361 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_060_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Colombia. DesInventar records: 2,279 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_061_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Colombia. DesInventar records: 237 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_062_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Colombia. DesInventar records: 958 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_063_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLOOD) events in Colombia. DesInventar records: 1 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_064_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (FLOOD) events in Colombia. DesInventar records: 27 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_065_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLOOD) events in Colombia. DesInventar records: 199 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_066_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Colombia. DesInventar records: 23 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_067_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Colombia. DesInventar records: 1,131 events with data out of 15,109 total flood events (1984-2013)."
+          },
+          {
+            "id": "loss_068_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE) events in Colombia. DesInventar records: 3,212 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_069_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Colombia. DesInventar records: 212 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_070_landslide_damages_in_roads_mts",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from landslide (LANDSLIDE) events in Colombia. DesInventar records: 747 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_071_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Colombia. DesInventar records: 1,409 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_072_landslide_education_centers",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from landslide (LANDSLIDE) events in Colombia. DesInventar records: 262 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_073_landslide_evacuated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from landslide (LANDSLIDE) events in Colombia. DesInventar records: 142 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_074_landslide_hospitals",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from landslide (LANDSLIDE) events in Colombia. DesInventar records: 34 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_075_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE) events in Colombia. DesInventar records: 2,153 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_076_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Colombia. DesInventar records: 2,060 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_077_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (LANDSLIDE) events in Colombia. DesInventar records: 749 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_078_landslide_losses_local",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from landslide (LANDSLIDE) events in Colombia. DesInventar records: 205 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_079_landslide_losses_usd",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from landslide (LANDSLIDE) events in Colombia. DesInventar records: 4 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_080_landslide_lost_cattle",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from landslide (LANDSLIDE) events in Colombia. DesInventar records: 4 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_081_landslide_missing",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from landslide (LANDSLIDE) events in Colombia. DesInventar records: 140 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_082_landslide_relocated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from landslide (LANDSLIDE) events in Colombia. DesInventar records: 7 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_083_landslide_victims",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE) events in Colombia. DesInventar records: 471 events with data out of 9,041 total landslide events (1984-2013)."
+          },
+          {
+            "id": "loss_084_landslide_losses_usd",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_mudflow",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from landslide (SEDIMENTATION) events in Colombia. DesInventar records: 1 events with data out of 12 total landslide events (1984-1985)."
+          },
+          {
+            "id": "loss_085_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (AVALANCHE) events in Colombia. DesInventar records: 23 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_086_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (AVALANCHE) events in Colombia. DesInventar records: 1 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_087_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (AVALANCHE) events in Colombia. DesInventar records: 3 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_088_landslide_education_centers",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from landslide (AVALANCHE) events in Colombia. DesInventar records: 2 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_089_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (AVALANCHE) events in Colombia. DesInventar records: 14 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_090_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (AVALANCHE) events in Colombia. DesInventar records: 12 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_091_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (AVALANCHE) events in Colombia. DesInventar records: 3 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_092_landslide_missing",
+            "hazard_type": "landslide",
+            "hazard_process": "snow_avalanche",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from landslide (AVALANCHE) events in Colombia. DesInventar records: 2 events with data out of 25 total landslide events (1995-2009)."
+          },
+          {
+            "id": "loss_093_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 42 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_094_strongwind_damages_in_crops_ha",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 7 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_095_strongwind_damages_in_roads_mts",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 5 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_096_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 75 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_097_strongwind_education_centers",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 17 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_098_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 4 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_099_strongwind_hospitals",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 5 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_100_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 48 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_101_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 94 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_102_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 54 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_103_strongwind_losses_local",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 38 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_104_strongwind_losses_usd",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 1 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_105_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 4 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_106_strongwind_victims",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 41 events with data out of 348 total strong wind events (1976-2013)."
+          },
+          {
+            "id": "loss_107_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (HURRICANE) events in Colombia. DesInventar records: 4 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_108_strongwind_damages_in_roads_mts",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from strong wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_109_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (HURRICANE) events in Colombia. DesInventar records: 3 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_110_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_111_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (HURRICANE) events in Colombia. DesInventar records: 2 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_112_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (HURRICANE) events in Colombia. DesInventar records: 5 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_113_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_114_strongwind_losses_local",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from strong wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_115_strongwind_victims",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from strong wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of 7 total strong wind events (1963-1988)."
+          },
+          {
+            "id": "loss_116_tsunami_affected",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from tsunami (TSUNAMI) events in Colombia. DesInventar records: 1 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_117_tsunami_deaths",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events in Colombia. DesInventar records: 4 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_118_tsunami_hospitals",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from tsunami (TSUNAMI) events in Colombia. DesInventar records: 1 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_119_tsunami_houses_damaged",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from tsunami (TSUNAMI) events in Colombia. DesInventar records: 5 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_120_tsunami_houses_destroyed",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in Colombia. DesInventar records: 3 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_121_tsunami_injured",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from tsunami (TSUNAMI) events in Colombia. DesInventar records: 5 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_122_tsunami_missing",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from tsunami (TSUNAMI) events in Colombia. DesInventar records: 3 events with data out of 5 total tsunami events (1979-1979)."
+          },
+          {
+            "id": "loss_123_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE) events in Colombia. DesInventar records: 893 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_124_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE) events in Colombia. DesInventar records: 10 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_125_wildfire_damages_in_roads_mts",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from wildfire (FIRE) events in Colombia. DesInventar records: 1 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_126_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE) events in Colombia. DesInventar records: 274 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_127_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE) events in Colombia. DesInventar records: 27 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_128_wildfire_evacuated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from wildfire (FIRE) events in Colombia. DesInventar records: 18 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_129_wildfire_hospitals",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from wildfire (FIRE) events in Colombia. DesInventar records: 14 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_130_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE) events in Colombia. DesInventar records: 401 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_131_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE) events in Colombia. DesInventar records: 922 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_132_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE) events in Colombia. DesInventar records: 417 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_133_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "COP"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE) events in Colombia. DesInventar records: 901 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_134_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE) events in Colombia. DesInventar records: 1 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_135_wildfire_missing",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from wildfire (FIRE) events in Colombia. DesInventar records: 4 events with data out of 2,588 total wildfire events (1984-2013)."
+          },
+          {
+            "id": "loss_136_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE) events in Colombia. DesInventar records: 476 events with data out of 2,588 total wildfire events (1984-2013)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-criundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-criundrr_desinventar.json
@@ -1,0 +1,1397 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-criundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Costa Rica",
+      "description": "National disaster loss inventory for Costa Rica from the DesInventar Sendai Framework Monitor database, compiled by Comision Nacional de Prevencion de Riesgos y Atencion de Emergencias (CNE) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 13,693 event-level loss records covering 1970-2016, with observed impacts from coastal_flood, convective_storm, drought, earthquake, flood, landslide, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Costa Rica from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Costa Rica, maintained by Comision Nacional de Prevencion de Riesgos y Atencion de Emergencias (CNE). Covers 13,693 observed disaster events from 1970-2016. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "CRI"
+        ],
+        "bbox": [
+          -87.12,
+          5.52,
+          -82.56,
+          11.21
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Costa Rica",
+            "uri": "https://www.geonames.org/3624060/costa-rica.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Comision Nacional de Prevencion de Riesgos y Atencion de Emergencias (CNE)",
+            "url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Costa Rica maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Costa Rica",
+          "url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Costa Rica",
+          "description": "Disaster data for Costa Rica",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3/resource/293b09b9-84bb-44e2-a674-6a2d6d219100/download/costarica.zip",
+          "access_url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster tabular data for Costa Rica",
+          "description": "Disaster tabular data for Costa Rica",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3/resource/d574ac1d-d41e-436a-b108-905d6de744e0/download/di_report-costarica.xls",
+          "access_url": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_coastalflood_affected",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from coastal flood (SURGE) events in Costa Rica. DesInventar records: 1 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_002_coastalflood_damages_in_roads_mts",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from coastal flood (SURGE) events in Costa Rica. DesInventar records: 2 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_003_coastalflood_deaths",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from coastal flood (SURGE) events in Costa Rica. DesInventar records: 5 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_004_coastalflood_evacuated",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from coastal flood (SURGE) events in Costa Rica. DesInventar records: 3 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_005_coastalflood_houses_damaged",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from coastal flood (SURGE) events in Costa Rica. DesInventar records: 22 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_006_coastalflood_houses_destroyed",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from coastal flood (SURGE) events in Costa Rica. DesInventar records: 6 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_007_coastalflood_injured",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from coastal flood (SURGE) events in Costa Rica. DesInventar records: 2 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_008_coastalflood_losses_local",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "CRC"
+            },
+            "description": "Observed total economic losses in local currency from coastal flood (SURGE) events in Costa Rica. DesInventar records: 1 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_009_coastalflood_victims",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from coastal flood (SURGE) events in Costa Rica. DesInventar records: 17 events with data out of 59 total coastal flood events (1970-2015)."
+          },
+          {
+            "id": "loss_010_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (HAILSTORM) events in Costa Rica. DesInventar records: 2 events with data out of 2 total convective storm events (1993-2012)."
+          },
+          {
+            "id": "loss_011_convectivestorm_victims",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from convective storm (HAILSTORM) events in Costa Rica. DesInventar records: 1 events with data out of 2 total convective storm events (1993-2012)."
+          },
+          {
+            "id": "loss_012_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Costa Rica. DesInventar records: 29 events with data out of 438 total drought events (1972-2014)."
+          },
+          {
+            "id": "loss_013_drought_losses_local",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "CRC"
+            },
+            "description": "Observed total economic losses in local currency from drought (DROUGHT) events in Costa Rica. DesInventar records: 25 events with data out of 438 total drought events (1972-2014)."
+          },
+          {
+            "id": "loss_014_drought_losses_usd",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from drought (DROUGHT) events in Costa Rica. DesInventar records: 18 events with data out of 438 total drought events (1972-2014)."
+          },
+          {
+            "id": "loss_015_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (DROUGHT) events in Costa Rica. DesInventar records: 1 events with data out of 438 total drought events (1972-2014)."
+          },
+          {
+            "id": "loss_016_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (DROUGHT) events in Costa Rica. DesInventar records: 22 events with data out of 438 total drought events (1972-2014)."
+          },
+          {
+            "id": "loss_017_earthquake_deaths",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 15 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_018_earthquake_education_centers",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 77 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_019_earthquake_evacuated",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 10 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_020_earthquake_hospitals",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 22 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_021_earthquake_houses_damaged",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 148 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_022_earthquake_houses_destroyed",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 132 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_023_earthquake_losses_local",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "CRC"
+            },
+            "description": "Observed total economic losses in local currency from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 6 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_024_earthquake_losses_usd",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_025_earthquake_lost_cattle",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_026_earthquake_missing",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 1 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_027_earthquake_relocated",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_028_earthquake_victims",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 150 events with data out of 348 total earthquake events (1973-2012)."
+          },
+          {
+            "id": "loss_029_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Costa Rica. DesInventar records: 105 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_030_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Costa Rica. DesInventar records: 10 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_031_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (FLOOD) events in Costa Rica. DesInventar records: 49 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_032_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Costa Rica. DesInventar records: 68 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_033_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Costa Rica. DesInventar records: 170 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_034_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD) events in Costa Rica. DesInventar records: 795 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_035_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Costa Rica. DesInventar records: 25 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_036_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Costa Rica. DesInventar records: 3,716 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_037_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Costa Rica. DesInventar records: 220 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_038_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Costa Rica. DesInventar records: 10 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_039_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "CRC"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Costa Rica. DesInventar records: 25 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_040_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLOOD) events in Costa Rica. DesInventar records: 4 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_041_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLOOD) events in Costa Rica. DesInventar records: 13 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_042_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Costa Rica. DesInventar records: 19 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_043_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Costa Rica. DesInventar records: 2,394 events with data out of 8,334 total flood events (1970-2016)."
+          },
+          {
+            "id": "loss_044_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 44 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_045_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 4 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_046_landslide_damages_in_roads_mts",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 212 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_047_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 85 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_048_landslide_education_centers",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 33 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_049_landslide_evacuated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 106 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_050_landslide_hospitals",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 3 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_051_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 1,402 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_052_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 154 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_053_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 14 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_054_landslide_losses_local",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "CRC"
+            },
+            "description": "Observed total economic losses in local currency from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 24 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_055_landslide_losses_usd",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 8 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_056_landslide_lost_cattle",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 2 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_057_landslide_missing",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 7 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_058_landslide_relocated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 7 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_059_landslide_victims",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 680 events with data out of 3,596 total landslide events (1970-2016)."
+          },
+          {
+            "id": "loss_060_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (STORM) events in Costa Rica. DesInventar records: 3 events with data out of 14 total strong wind events (1995-2014)."
+          },
+          {
+            "id": "loss_061_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (STORM) events in Costa Rica. DesInventar records: 12 events with data out of 14 total strong wind events (1995-2014)."
+          },
+          {
+            "id": "loss_062_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (STORM) events in Costa Rica. DesInventar records: 2 events with data out of 14 total strong wind events (1995-2014)."
+          },
+          {
+            "id": "loss_063_strongwind_victims",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from strong wind (STORM) events in Costa Rica. DesInventar records: 10 events with data out of 14 total strong wind events (1995-2014)."
+          },
+          {
+            "id": "loss_064_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE) events in Costa Rica. DesInventar records: 10 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_065_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE) events in Costa Rica. DesInventar records: 56 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_066_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE) events in Costa Rica. DesInventar records: 12 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_067_wildfire_hospitals",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from wildfire (FIRE) events in Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_068_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE) events in Costa Rica. DesInventar records: 202 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_069_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE) events in Costa Rica. DesInventar records: 463 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_070_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE) events in Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_071_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "CRC"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE) events in Costa Rica. DesInventar records: 242 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_072_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (FIRE) events in Costa Rica. DesInventar records: 229 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_073_wildfire_relocated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from wildfire (FIRE) events in Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire events (1980-2013)."
+          },
+          {
+            "id": "loss_074_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE) events in Costa Rica. DesInventar records: 172 events with data out of 902 total wildfire events (1980-2013)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-ethundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-ethundrr_desinventar.json
@@ -1,0 +1,895 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-ethundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Ethiopia",
+      "description": "National disaster loss inventory for Ethiopia from the DesInventar Sendai Framework Monitor database, compiled by Disaster Risk Management and Food Security Sector and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 9,109 event-level loss records covering 1992-2013, with observed impacts from convective_storm, drought, earthquake, extreme_temperature, flood, landslide, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Ethiopia from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Ethiopia, maintained by Disaster Risk Management and Food Security Sector. Covers 9,109 observed disaster events from 1992-2013. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "ETH"
+        ],
+        "bbox": [
+          32.99,
+          3.4,
+          47.98,
+          14.88
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Ethiopia",
+            "uri": "https://www.geonames.org/337996/ethiopia.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Disaster Risk Management and Food Security Sector",
+            "url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Ethiopia maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Ethiopia",
+          "url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "ETH.zip",
+          "description": "DesInventar disaster loss data for Ethiopia",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc/resource/b4577974-a689-40e0-a64d-6ea232aea57b/download/eth.zip",
+          "access_url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc"
+        },
+        {
+          "id": "resource_002",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims   Affected, Relocated, Evacuated, Losses and Damages in crops Ha.",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims   Affected, Relocated, Evacuated, Losses and Damages in crops Ha.",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc/resource/e5bc14ca-9408-4e9d-ba04-99a273259fc6/download/ethiopa.xls",
+          "access_url": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_convectivestorm_affected",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 30 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_002_convectivestorm_damages_in_crops_ha",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 141 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_003_convectivestorm_deaths",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 17 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_004_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 1 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_005_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 27 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_006_convectivestorm_injured",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 5 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_007_convectivestorm_relocated",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 13 events with data out of 242 total convective storm events (1996-2012)."
+          },
+          {
+            "id": "loss_008_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Ethiopia. DesInventar records: 5,569 events with data out of 5,802 total drought events (1992-2013)."
+          },
+          {
+            "id": "loss_009_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Ethiopia. DesInventar records: 75 events with data out of 5,802 total drought events (1992-2013)."
+          },
+          {
+            "id": "loss_010_drought_deaths",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from drought (DROUGHT) events in Ethiopia. DesInventar records: 2 events with data out of 5,802 total drought events (1992-2013)."
+          },
+          {
+            "id": "loss_011_drought_relocated",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from drought (DROUGHT) events in Ethiopia. DesInventar records: 7 events with data out of 5,802 total drought events (1992-2013)."
+          },
+          {
+            "id": "loss_012_earthquake_affected",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from earthquake (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of 3 total earthquake events (1993-2005)."
+          },
+          {
+            "id": "loss_013_earthquake_houses_destroyed",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of 3 total earthquake events (1993-2005)."
+          },
+          {
+            "id": "loss_014_earthquake_injured",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from earthquake (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of 3 total earthquake events (1993-2005)."
+          },
+          {
+            "id": "loss_015_extremetemperature_affected",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from extreme temperature (FROST) events in Ethiopia. DesInventar records: 2 events with data out of 7 total extreme temperature events (1999-2005)."
+          },
+          {
+            "id": "loss_016_extremetemperature_damages_in_crops_ha",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_cold",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from extreme temperature (FROST) events in Ethiopia. DesInventar records: 6 events with data out of 7 total extreme temperature events (1999-2005)."
+          },
+          {
+            "id": "loss_017_extremetemperature_affected",
+            "hazard_type": "extreme_temperature",
+            "hazard_process": "extreme_heat",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from extreme temperature (HEAT WAVE) events in Ethiopia. DesInventar records: 1 events with data out of 2 total extreme temperature events (1996-1996)."
+          },
+          {
+            "id": "loss_018_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Ethiopia. DesInventar records: 926 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_019_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Ethiopia. DesInventar records: 392 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_020_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Ethiopia. DesInventar records: 179 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_021_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Ethiopia. DesInventar records: 4 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_022_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Ethiopia. DesInventar records: 1 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_023_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Ethiopia. DesInventar records: 31 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_024_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Ethiopia. DesInventar records: 141 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_025_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Ethiopia. DesInventar records: 27 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_026_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ETB"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Ethiopia. DesInventar records: 3 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_027_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Ethiopia. DesInventar records: 274 events with data out of 1,475 total flood events (2006-2013)."
+          },
+          {
+            "id": "loss_028_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 54 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_029_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 55 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_030_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 30 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_031_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 2 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_032_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 26 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_033_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 9 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_034_landslide_relocated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 33 events with data out of 141 total landslide events (2001-2013)."
+          },
+          {
+            "id": "loss_035_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar records: 12 events with data out of 27 total strong wind events (1996-2009)."
+          },
+          {
+            "id": "loss_036_strongwind_damages_in_crops_ha",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar records: 5 events with data out of 27 total strong wind events (1996-2009)."
+          },
+          {
+            "id": "loss_037_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar records: 2 events with data out of 27 total strong wind events (1996-2009)."
+          },
+          {
+            "id": "loss_038_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar records: 5 events with data out of 27 total strong wind events (1996-2009)."
+          },
+          {
+            "id": "loss_039_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 239 events with data out of 1,410 total wildfire events (2000-2013)."
+          },
+          {
+            "id": "loss_040_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 60 events with data out of 1,410 total wildfire events (2000-2013)."
+          },
+          {
+            "id": "loss_041_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 76 events with data out of 1,410 total wildfire events (2000-2013)."
+          },
+          {
+            "id": "loss_042_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 89 events with data out of 1,410 total wildfire events (2000-2013)."
+          },
+          {
+            "id": "loss_043_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 59 events with data out of 1,410 total wildfire events (2000-2013)."
+          },
+          {
+            "id": "loss_044_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "ETB"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 570 events with data out of 1,410 total wildfire events (2000-2013)."
+          },
+          {
+            "id": "loss_045_wildfire_relocated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 34 events with data out of 1,410 total wildfire events (2000-2013)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-idnundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-idnundrr_desinventar.json
@@ -1,0 +1,914 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-idnundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Indonesia",
+      "description": "National disaster loss inventory for Indonesia from the DesInventar Sendai Framework Monitor database, compiled by Badan Nasional Penanggulangan Bencana (BNPB) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 5,307 event-level loss records covering 1973-2012, with observed impacts from coastal_flood, drought, earthquake, tsunami, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Indonesia from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Indonesia, maintained by Badan Nasional Penanggulangan Bencana (BNPB). Covers 5,307 observed disaster events from 1973-2012. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "IDN"
+        ],
+        "bbox": [
+          95.01,
+          -10.92,
+          140.98,
+          5.91
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Indonesia",
+            "uri": "https://www.geonames.org/1643084/indonesia.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Badan Nasional Penanggulangan Bencana (BNPB)",
+            "url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Indonesia maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Indonesia",
+          "url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "IDN.zip",
+          "description": "DesInventar disaster loss data for Indonesia",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366/resource/71c78d9f-b219-4881-8c1d-f79654b8c32b/download/idn.zip",
+          "access_url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366"
+        },
+        {
+          "id": "resource_002",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366/resource/bc3bc1c5-89ff-4777-9299-dbd2d09e2033/download/indonesia.xls",
+          "access_url": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_coastalflood_affected",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from coastal flood (SURGE) events in Indonesia. DesInventar records: 32 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_002_coastalflood_damages_in_crops_ha",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from coastal flood (SURGE) events in Indonesia. DesInventar records: 5 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_003_coastalflood_deaths",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from coastal flood (SURGE) events in Indonesia. DesInventar records: 17 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_004_coastalflood_education_centers",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from coastal flood (SURGE) events in Indonesia. DesInventar records: 11 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_005_coastalflood_evacuated",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from coastal flood (SURGE) events in Indonesia. DesInventar records: 54 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_006_coastalflood_hospitals",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from coastal flood (SURGE) events in Indonesia. DesInventar records: 6 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_007_coastalflood_houses_damaged",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from coastal flood (SURGE) events in Indonesia. DesInventar records: 55 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_008_coastalflood_houses_destroyed",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from coastal flood (SURGE) events in Indonesia. DesInventar records: 93 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_009_coastalflood_injured",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from coastal flood (SURGE) events in Indonesia. DesInventar records: 18 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_010_coastalflood_losses_local",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "IDR"
+            },
+            "description": "Observed total economic losses in local currency from coastal flood (SURGE) events in Indonesia. DesInventar records: 38 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_011_coastalflood_missing",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from coastal flood (SURGE) events in Indonesia. DesInventar records: 7 events with data out of 270 total coastal flood events (2009-2011)."
+          },
+          {
+            "id": "loss_012_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Indonesia. DesInventar records: 38 events with data out of 1,748 total drought events (2004-2008)."
+          },
+          {
+            "id": "loss_013_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Indonesia. DesInventar records: 1,352 events with data out of 1,748 total drought events (2004-2008)."
+          },
+          {
+            "id": "loss_014_drought_deaths",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from drought (DROUGHT) events in Indonesia. DesInventar records: 1 events with data out of 1,748 total drought events (2004-2008)."
+          },
+          {
+            "id": "loss_015_drought_losses_local",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "IDR"
+            },
+            "description": "Observed total economic losses in local currency from drought (DROUGHT) events in Indonesia. DesInventar records: 8 events with data out of 1,748 total drought events (2004-2008)."
+          },
+          {
+            "id": "loss_016_earthquake_affected",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 29 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_017_earthquake_damages_in_crops_ha",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 5 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_018_earthquake_deaths",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 165 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_019_earthquake_education_centers",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 171 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_020_earthquake_evacuated",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 103 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_021_earthquake_hospitals",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 83 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_022_earthquake_houses_damaged",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 171 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_023_earthquake_houses_destroyed",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 188 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_024_earthquake_injured",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 169 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_025_earthquake_losses_local",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "IDR"
+            },
+            "description": "Observed total economic losses in local currency from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 32 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_026_earthquake_missing",
+            "hazard_type": "earthquake",
+            "hazard_process": "ground_motion",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 10 events with data out of 449 total earthquake events (1976-2004)."
+          },
+          {
+            "id": "loss_027_tsunami_damages_in_crops_ha",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 2 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_028_tsunami_deaths",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 11 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_029_tsunami_education_centers",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 2 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_030_tsunami_evacuated",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 2 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_031_tsunami_hospitals",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 1 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_032_tsunami_houses_damaged",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 1 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_033_tsunami_houses_destroyed",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 6 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_034_tsunami_injured",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 3 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_035_tsunami_missing",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 6 events with data out of 13 total tsunami events (1973-1977)."
+          },
+          {
+            "id": "loss_036_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 512 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_037_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 12 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_038_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 145 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_039_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 50 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_040_wildfire_evacuated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 465 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_041_wildfire_hospitals",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 14 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_042_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 92 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_043_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 1,088 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_044_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 166 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_045_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "IDR"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 1,310 events with data out of 2,827 total wildfire events (2005-2012)."
+          },
+          {
+            "id": "loss_046_wildfire_missing",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 5 events with data out of 2,827 total wildfire events (2005-2012)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-kenundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-kenundrr_desinventar.json
@@ -1,0 +1,1050 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-kenundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Kenya",
+      "description": "National disaster loss inventory for Kenya from the DesInventar Sendai Framework Monitor database, compiled by National Disaster Operations Centre (NDOC) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 1,857 event-level loss records covering 1997-2016, with observed impacts from convective_storm, drought, flood, landslide, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Kenya from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Kenya, maintained by National Disaster Operations Centre (NDOC). Covers 1,857 observed disaster events from 1997-2016. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "KEN"
+        ],
+        "bbox": [
+          33.89,
+          -4.68,
+          41.89,
+          5.03
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Kenya",
+            "uri": "https://www.geonames.org/192950/kenya.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "National Disaster Operations Centre (NDOC)",
+            "url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Kenya maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Kenya",
+          "url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Kenya",
+          "description": "Disaster data for Kenya",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d/resource/4d984de9-cd1b-483c-a887-860c9cb7a7c8/download/kenya.zip",
+          "access_url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster tabular data for Kenya",
+          "description": "Disaster tabular data for Kenya",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d/resource/e518eeff-0d26-4f7b-9ab8-47fdcd5865b8/download/di_report-kenya.xls",
+          "access_url": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_convectivestorm_affected",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_002_convectivestorm_deaths",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 14 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_003_convectivestorm_education_centers",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_004_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_005_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_006_convectivestorm_injured",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 7 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_007_convectivestorm_losses_local",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "KES"
+            },
+            "description": "Observed total economic losses in local currency from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_008_convectivestorm_lost_cattle",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 2 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_009_convectivestorm_missing",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total convective storm events (2011-2013)."
+          },
+          {
+            "id": "loss_010_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Kenya. DesInventar records: 165 events with data out of 569 total drought events (2009-2011)."
+          },
+          {
+            "id": "loss_011_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (DROUGHT) events in Kenya. DesInventar records: 1 events with data out of 569 total drought events (2009-2011)."
+          },
+          {
+            "id": "loss_012_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (DROUGHT) events in Kenya. DesInventar records: 2 events with data out of 569 total drought events (2009-2011)."
+          },
+          {
+            "id": "loss_013_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Kenya. DesInventar records: 207 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_014_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Kenya. DesInventar records: 34 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_015_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Kenya. DesInventar records: 236 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_016_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Kenya. DesInventar records: 1 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_017_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD) events in Kenya. DesInventar records: 9 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_018_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Kenya. DesInventar records: 32 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_019_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Kenya. DesInventar records: 136 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_020_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Kenya. DesInventar records: 23 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_021_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "KES"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Kenya. DesInventar records: 2 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_022_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (FLOOD) events in Kenya. DesInventar records: 20 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_023_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLOOD) events in Kenya. DesInventar records: 9 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_024_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Kenya. DesInventar records: 14 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_025_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Kenya. DesInventar records: 2 events with data out of 737 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_026_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (RAINS) events in Kenya. DesInventar records: 6 events with data out of 48 total flood events (2015-2016)."
+          },
+          {
+            "id": "loss_027_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (RAINS) events in Kenya. DesInventar records: 1 events with data out of 48 total flood events (2015-2016)."
+          },
+          {
+            "id": "loss_028_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (RAINS) events in Kenya. DesInventar records: 1 events with data out of 48 total flood events (2015-2016)."
+          },
+          {
+            "id": "loss_029_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (RAINS) events in Kenya. DesInventar records: 38 events with data out of 48 total flood events (2015-2016)."
+          },
+          {
+            "id": "loss_030_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE) events in Kenya. DesInventar records: 11 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_031_landslide_damages_in_crops_ha",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Kenya. DesInventar records: 1 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_032_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Kenya. DesInventar records: 26 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_033_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE) events in Kenya. DesInventar records: 2 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_034_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Kenya. DesInventar records: 13 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_035_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (LANDSLIDE) events in Kenya. DesInventar records: 5 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_036_landslide_missing",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from landslide (LANDSLIDE) events in Kenya. DesInventar records: 1 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_037_landslide_relocated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from landslide (LANDSLIDE) events in Kenya. DesInventar records: 2 events with data out of 44 total landslide events (2013-2016)."
+          },
+          {
+            "id": "loss_038_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_mudflow",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (MUDSLIDE) events in Kenya. DesInventar records: 4 events with data out of 6 total landslide events (2009-2015)."
+          },
+          {
+            "id": "loss_039_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_mudflow",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (MUDSLIDE) events in Kenya. DesInventar records: 1 events with data out of 6 total landslide events (2009-2015)."
+          },
+          {
+            "id": "loss_040_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 5 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_041_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 6 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_042_strongwind_education_centers",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_043_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 4 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_044_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_045_strongwind_losses_local",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "KES"
+            },
+            "description": "Observed total economic losses in local currency from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_046_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with data out of 19 total strong wind events (2010-2015)."
+          },
+          {
+            "id": "loss_047_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 3 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_048_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 23 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_049_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 114 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_050_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 15 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_051_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 69 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_052_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 79 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_053_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "KES"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 16 events with data out of 415 total wildfire events (1997-2016)."
+          },
+          {
+            "id": "loss_054_wildfire_relocated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 1 events with data out of 415 total wildfire events (1997-2016)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-khmundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-khmundrr_desinventar.json
@@ -1,0 +1,826 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-khmundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Cambodia",
+      "description": "National disaster loss inventory for Cambodia from the DesInventar Sendai Framework Monitor database, compiled by National Committee for Disaster Management (NCDM) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 7,957 event-level loss records covering 2009-2016, with observed impacts from drought, flood, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Cambodia from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Cambodia, maintained by National Committee for Disaster Management (NCDM). Covers 7,957 observed disaster events from 2009-2016. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "KHM"
+        ],
+        "bbox": [
+          102.31,
+          10.42,
+          107.61,
+          14.7
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Cambodia",
+            "uri": "https://www.geonames.org/1831722/cambodia.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "National Committee for Disaster Management (NCDM)",
+            "url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Cambodia maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage data for Cambodia",
+          "url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Cambodia",
+          "description": "Disaster data for Cambodia",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738/resource/bbb63796-5079-45af-b461-6f8b085b91a9/download/camdodia.zip",
+          "access_url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster Tabular data for Cambodia",
+          "description": "Disaster Tabular data for Cambodia",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738/resource/484f981d-278f-4bf0-8581-1fc38d70232a/download/di_report-cambodia.xls",
+          "access_url": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (Drought) events in Cambodia. DesInventar records: 32 events with data out of 1,300 total drought events (2011-2016)."
+          },
+          {
+            "id": "loss_002_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (Drought) events in Cambodia. DesInventar records: 552 events with data out of 1,300 total drought events (2011-2016)."
+          },
+          {
+            "id": "loss_003_drought_damages_in_roads_mts",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from drought (Drought) events in Cambodia. DesInventar records: 4 events with data out of 1,300 total drought events (2011-2016)."
+          },
+          {
+            "id": "loss_004_drought_education_centers",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from drought (Drought) events in Cambodia. DesInventar records: 1 events with data out of 1,300 total drought events (2011-2016)."
+          },
+          {
+            "id": "loss_005_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (Drought) events in Cambodia. DesInventar records: 2 events with data out of 1,300 total drought events (2011-2016)."
+          },
+          {
+            "id": "loss_006_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (Drought) events in Cambodia. DesInventar records: 334 events with data out of 1,300 total drought events (2011-2016)."
+          },
+          {
+            "id": "loss_007_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (Flood) events in Cambodia. DesInventar records: 1,780 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_008_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (Flood) events in Cambodia. DesInventar records: 983 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_009_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (Flood) events in Cambodia. DesInventar records: 394 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_010_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (Flood) events in Cambodia. DesInventar records: 59 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_011_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (Flood) events in Cambodia. DesInventar records: 421 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_012_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (Flood) events in Cambodia. DesInventar records: 27 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_013_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (Flood) events in Cambodia. DesInventar records: 222 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_014_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (Flood) events in Cambodia. DesInventar records: 184 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_015_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (Flood) events in Cambodia. DesInventar records: 38 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_016_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (Flood) events in Cambodia. DesInventar records: 88 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_017_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (Flood) events in Cambodia. DesInventar records: 15 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_018_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (Flood) events in Cambodia. DesInventar records: 1,546 events with data out of 3,389 total flood events (2011-2014)."
+          },
+          {
+            "id": "loss_019_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (Storm) events in Cambodia. DesInventar records: 4 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_020_strongwind_damages_in_crops_ha",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from strong wind (Storm) events in Cambodia. DesInventar records: 13 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_021_strongwind_damages_in_roads_mts",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from strong wind (Storm) events in Cambodia. DesInventar records: 3 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_022_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (Storm) events in Cambodia. DesInventar records: 58 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_023_strongwind_education_centers",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from strong wind (Storm) events in Cambodia. DesInventar records: 26 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_024_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (Storm) events in Cambodia. DesInventar records: 2 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_025_strongwind_hospitals",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from strong wind (Storm) events in Cambodia. DesInventar records: 7 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_026_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (Storm) events in Cambodia. DesInventar records: 787 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_027_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (Storm) events in Cambodia. DesInventar records: 957 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_028_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (Storm) events in Cambodia. DesInventar records: 128 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_029_strongwind_lost_cattle",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from strong wind (Storm) events in Cambodia. DesInventar records: 23 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_030_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (Storm) events in Cambodia. DesInventar records: 1 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_031_strongwind_victims",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from strong wind (Storm) events in Cambodia. DesInventar records: 681 events with data out of 1,454 total strong wind events (2009-2016)."
+          },
+          {
+            "id": "loss_032_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (Fire) events in Cambodia. DesInventar records: 5 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_033_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (Fire) events in Cambodia. DesInventar records: 1 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_034_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (Fire) events in Cambodia. DesInventar records: 53 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_035_wildfire_evacuated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from wildfire (Fire) events in Cambodia. DesInventar records: 2 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_036_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (Fire) events in Cambodia. DesInventar records: 220 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_037_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (Fire) events in Cambodia. DesInventar records: 1,249 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_038_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (Fire) events in Cambodia. DesInventar records: 46 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_039_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (Fire) events in Cambodia. DesInventar records: 1 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_040_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (Fire) events in Cambodia. DesInventar records: 2 events with data out of 1,814 total wildfire events (2013-2016)."
+          },
+          {
+            "id": "loss_041_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (Fire) events in Cambodia. DesInventar records: 579 events with data out of 1,814 total wildfire events (2013-2016)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-lkaundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-lkaundrr_desinventar.json
@@ -1,0 +1,1339 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-lkaundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Sri Lanka",
+      "description": "National disaster loss inventory for Sri Lanka from the DesInventar Sendai Framework Monitor database, compiled by Disaster Management Centre (DMC) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 17,729 event-level loss records covering historical, with observed impacts from coastal_flood, convective_storm, drought, extreme_temperature, flood, landslide, strong_wind, tsunami, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Sri Lanka from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Sri Lanka, maintained by Disaster Management Centre (DMC). Covers 17,729 observed disaster events from historical. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "LKA"
+        ],
+        "bbox": [
+          79.66,
+          5.92,
+          81.89,
+          9.83
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Sri Lanka",
+            "uri": "https://www.geonames.org/1227603/sri-lanka.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Disaster Management Centre (DMC)",
+            "url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Sri Lanka maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Sri Lanka",
+          "url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Sri Lanka",
+          "description": "Disaster data for Sri Lanka",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184/resource/49adba32-509f-49e7-b63e-928ef743c52e/download/srilanka.zip",
+          "access_url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster tabular data for Sri Lanka",
+          "description": "Disaster tabular data for Sri Lanka",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184/resource/4cb4bd14-e5ba-4443-af23-948bfb05f479/download/di_report-srilanka.xls",
+          "access_url": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_coastalflood_affected",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 20 events with data out of 40 total coastal flood events."
+          },
+          {
+            "id": "loss_002_coastalflood_deaths",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 4 events with data out of 40 total coastal flood events."
+          },
+          {
+            "id": "loss_003_coastalflood_evacuated",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 1 events with data out of 40 total coastal flood events."
+          },
+          {
+            "id": "loss_004_coastalflood_houses_damaged",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 7 events with data out of 40 total coastal flood events."
+          },
+          {
+            "id": "loss_005_coastalflood_houses_destroyed",
+            "hazard_type": "coastal_flood",
+            "hazard_process": "storm_surge",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 2 events with data out of 40 total coastal flood events."
+          },
+          {
+            "id": "loss_006_convectivestorm_affected",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective storm events."
+          },
+          {
+            "id": "loss_007_convectivestorm_deaths",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective storm events."
+          },
+          {
+            "id": "loss_008_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective storm events."
+          },
+          {
+            "id": "loss_009_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective storm events."
+          },
+          {
+            "id": "loss_010_convectivestorm_injured",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective storm events."
+          },
+          {
+            "id": "loss_011_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1,327 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_012_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Sri Lanka. DesInventar records: 97 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_013_drought_deaths",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_014_drought_evacuated",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_015_drought_houses_damaged",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from drought (DROUGHT) events in Sri Lanka. DesInventar records: 3 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_016_drought_houses_destroyed",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_017_drought_missing",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought events."
+          },
+          {
+            "id": "loss_018_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 5,541 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_019_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 5 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_020_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 252 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_021_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 2 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_022_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 82 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_023_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 1 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_024_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 2,297 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_025_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 1,229 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_026_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 80 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_027_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "LKR"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 7 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_028_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 10 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_029_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 5 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_030_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 2 events with data out of 6,828 total flood events."
+          },
+          {
+            "id": "loss_031_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (RAINS) events in Sri Lanka. DesInventar records: 2,405 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_032_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (RAINS) events in Sri Lanka. DesInventar records: 23 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_033_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (RAINS) events in Sri Lanka. DesInventar records: 19 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_034_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (RAINS) events in Sri Lanka. DesInventar records: 1,829 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_035_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (RAINS) events in Sri Lanka. DesInventar records: 198 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_036_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (RAINS) events in Sri Lanka. DesInventar records: 17 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_037_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (RAINS) events in Sri Lanka. DesInventar records: 1 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_038_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "pluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (RAINS) events in Sri Lanka. DesInventar records: 1 events with data out of 2,533 total flood events."
+          },
+          {
+            "id": "loss_039_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 1,545 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_040_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 174 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_041_landslide_evacuated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 46 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_042_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 1,067 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_043_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 316 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_044_landslide_injured",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 125 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_045_landslide_losses_local",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "LKR"
+            },
+            "description": "Observed total economic losses in local currency from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_046_landslide_missing",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_047_landslide_relocated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 8 events with data out of 2,100 total landslide events."
+          },
+          {
+            "id": "loss_048_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (STORM) events in Sri Lanka. DesInventar records: 2 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_049_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (STORM) events in Sri Lanka. DesInventar records: 2 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_050_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (STORM) events in Sri Lanka. DesInventar records: 2 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_051_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 117 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_052_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 27 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_053_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 4 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_054_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 106 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_055_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 36 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_056_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 16 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_057_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 2 events with data out of 164 total strong wind events."
+          },
+          {
+            "id": "loss_058_tsunami_affected",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 69 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_059_tsunami_deaths",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 13 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_060_tsunami_houses_damaged",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 57 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_061_tsunami_houses_destroyed",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 57 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_062_tsunami_injured",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 40 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_063_tsunami_losses_local",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "LKR"
+            },
+            "description": "Observed total economic losses in local currency from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 3 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_064_tsunami_missing",
+            "hazard_type": "tsunami",
+            "hazard_process": "tsunami",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 35 events with data out of 89 total tsunami events."
+          },
+          {
+            "id": "loss_065_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 983 events with data out of 3,697 total wildfire events."
+          },
+          {
+            "id": "loss_066_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 61 events with data out of 3,697 total wildfire events."
+          },
+          {
+            "id": "loss_067_wildfire_evacuated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 16 events with data out of 3,697 total wildfire events."
+          },
+          {
+            "id": "loss_068_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 423 events with data out of 3,697 total wildfire events."
+          },
+          {
+            "id": "loss_069_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 538 events with data out of 3,697 total wildfire events."
+          },
+          {
+            "id": "loss_070_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 36 events with data out of 3,697 total wildfire events."
+          },
+          {
+            "id": "loss_071_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "LKR"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 3 events with data out of 3,697 total wildfire events."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-mdgundrr_desinventar_a.json
+++ b/_datasets/json/rdls_lss-mdgundrr_desinventar_a.json
@@ -1,0 +1,332 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-mdgundrr_desinventar_a",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Madagascar",
+      "description": "National disaster loss inventory for Madagascar from the DesInventar Sendai Framework Monitor database, compiled by Cellule de Prevention et Gestion des Urgences (CPGU) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 227 event-level loss records covering 2009-2009, with observed impacts from flood, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Madagascar from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Madagascar, maintained by Cellule de Prevention et Gestion des Urgences (CPGU). Covers 227 observed disaster events from 2009-2009. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "MDG"
+        ],
+        "bbox": [
+          43.22,
+          -25.6,
+          50.5,
+          -11.94
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Madagascar",
+            "uri": "https://www.geonames.org/1062947/madagascar.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Cellule de Prevention et Gestion des Urgences (CPGU)",
+            "url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Madagascar maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Madagascar",
+          "url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff/resource/7775fc9a-2f75-4015-85e7-1d5943a9d2ce/download/madagascar.xlsx",
+          "access_url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff"
+        },
+        {
+          "id": "resource_002",
+          "title": "Madagascar.zip",
+          "description": "DesInventar disaster loss data for Madagascar",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff/resource/0090e8a4-8500-44e9-9ca8-659cf30ea97b/download/madagascar.zip",
+          "access_url": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Madagascar. DesInventar records: 9 events with data out of 9 total flood events."
+          },
+          {
+            "id": "loss_002_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Madagascar. DesInventar records: 4 events with data out of 9 total flood events."
+          },
+          {
+            "id": "loss_003_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Madagascar. DesInventar records: 2 events with data out of 9 total flood events."
+          },
+          {
+            "id": "loss_004_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Madagascar. DesInventar records: 4 events with data out of 9 total flood events."
+          },
+          {
+            "id": "loss_005_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Madagascar. DesInventar records: 9 events with data out of 9 total flood events."
+          },
+          {
+            "id": "loss_006_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE) events in Madagascar. DesInventar records: 159 events with data out of 218 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_007_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE) events in Madagascar. DesInventar records: 14 events with data out of 218 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_008_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE) events in Madagascar. DesInventar records: 9 events with data out of 218 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_009_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE) events in Madagascar. DesInventar records: 1 events with data out of 218 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_010_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE) events in Madagascar. DesInventar records: 198 events with data out of 218 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_011_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE) events in Madagascar. DesInventar records: 24 events with data out of 218 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_012_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE) events in Madagascar. DesInventar records: 136 events with data out of 218 total wildfire events (2009-2009)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-mdgundrr_desinventar_b.json
+++ b/_datasets/json/rdls_lss-mdgundrr_desinventar_b.json
@@ -1,0 +1,417 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-mdgundrr_desinventar_b",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Madagascar",
+      "description": "National disaster loss inventory for Madagascar from the DesInventar Sendai Framework Monitor database, compiled by Cellule de Prevention et Gestion des Urgences (CPGU) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 244 event-level loss records covering 2008-2015, with observed impacts from drought, flood, landslide, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Madagascar from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Madagascar, maintained by Cellule de Prevention et Gestion des Urgences (CPGU). Covers 244 observed disaster events from 2008-2015. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "MDG"
+        ],
+        "bbox": [
+          43.22,
+          -25.6,
+          50.5,
+          -11.94
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Madagascar",
+            "uri": "https://www.geonames.org/1062947/madagascar.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Cellule de Prevention et Gestion des Urgences (CPGU)",
+            "url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Madagascar maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Madagascar",
+          "url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Madagascar",
+          "description": "Disaster data for Madagascar",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2/resource/0250ddbb-b0ad-4fad-a716-e7f26fbd0164/download/madagascar.zip",
+          "access_url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster tabular data for Madagascar",
+          "description": "Disaster tabular data for Madagascar",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2/resource/11f149bb-31df-42e4-b47d-0b18216e9f2d/download/di_report-madagascar.xls",
+          "access_url": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_drought_deaths",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from drought (DROUGHT) events in Madagascar. DesInventar records: 3 events with data out of 3 total drought events (2015-2015)."
+          },
+          {
+            "id": "loss_002_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Madagascar. DesInventar records: 19 events with data out of 20 total flood events (2008-2015)."
+          },
+          {
+            "id": "loss_003_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Madagascar. DesInventar records: 9 events with data out of 20 total flood events (2008-2015)."
+          },
+          {
+            "id": "loss_004_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Madagascar. DesInventar records: 8 events with data out of 20 total flood events (2008-2015)."
+          },
+          {
+            "id": "loss_005_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Madagascar. DesInventar records: 10 events with data out of 20 total flood events (2008-2015)."
+          },
+          {
+            "id": "loss_006_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Madagascar. DesInventar records: 7 events with data out of 20 total flood events (2008-2015)."
+          },
+          {
+            "id": "loss_007_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Madagascar. DesInventar records: 19 events with data out of 20 total flood events (2008-2015)."
+          },
+          {
+            "id": "loss_008_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (LANDSLIDE) events in Madagascar. DesInventar records: 2 events with data out of 2 total landslide events (2015-2015)."
+          },
+          {
+            "id": "loss_009_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events in Madagascar. DesInventar records: 2 events with data out of 2 total landslide events (2015-2015)."
+          },
+          {
+            "id": "loss_010_landslide_victims",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE) events in Madagascar. DesInventar records: 1 events with data out of 2 total landslide events (2015-2015)."
+          },
+          {
+            "id": "loss_011_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE) events in Madagascar. DesInventar records: 159 events with data out of 219 total wildfire events (2009-2015)."
+          },
+          {
+            "id": "loss_012_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE) events in Madagascar. DesInventar records: 14 events with data out of 219 total wildfire events (2009-2015)."
+          },
+          {
+            "id": "loss_013_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE) events in Madagascar. DesInventar records: 9 events with data out of 219 total wildfire events (2009-2015)."
+          },
+          {
+            "id": "loss_014_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE) events in Madagascar. DesInventar records: 1 events with data out of 219 total wildfire events (2009-2015)."
+          },
+          {
+            "id": "loss_015_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE) events in Madagascar. DesInventar records: 199 events with data out of 219 total wildfire events (2009-2015)."
+          },
+          {
+            "id": "loss_016_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE) events in Madagascar. DesInventar records: 24 events with data out of 219 total wildfire events (2009-2015)."
+          },
+          {
+            "id": "loss_017_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE) events in Madagascar. DesInventar records: 137 events with data out of 219 total wildfire events (2009-2015)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-mliundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-mliundrr_desinventar.json
@@ -1,0 +1,673 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-mliundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Mali",
+      "description": "National disaster loss inventory for Mali from the DesInventar Sendai Framework Monitor database, compiled by Direction Nationale de la Protection Civile and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 1,718 event-level loss records covering 2005-2011, with observed impacts from convective_storm, drought, flood, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Mali from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Mali, maintained by Direction Nationale de la Protection Civile. Covers 1,718 observed disaster events from 2005-2011. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "MLI"
+        ],
+        "bbox": [
+          -12.26,
+          10.14,
+          4.24,
+          25.0
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Mali",
+            "uri": "https://www.geonames.org/2453866/mali.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Direction Nationale de la Protection Civile",
+            "url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Mali maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Mali",
+          "url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796/resource/b9e494bf-b6e6-4777-8745-9d55d86744f9/download/mali.xlsx",
+          "access_url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796"
+        },
+        {
+          "id": "resource_002",
+          "title": "Mali.zip",
+          "description": "DesInventar disaster loss data for Mali",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796/resource/2aac7c1d-8d30-41e1-b6d3-42a8cbcb0594/download/mali.zip",
+          "access_url": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_convectivestorm_affected",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from convective storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 2 events with data out of 9 total convective storm events (2005-2005)."
+          },
+          {
+            "id": "loss_002_convectivestorm_deaths",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 5 events with data out of 9 total convective storm events (2005-2005)."
+          },
+          {
+            "id": "loss_003_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 1 events with data out of 9 total convective storm events (2005-2005)."
+          },
+          {
+            "id": "loss_004_convectivestorm_injured",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 1 events with data out of 9 total convective storm events (2005-2005)."
+          },
+          {
+            "id": "loss_005_convectivestorm_lost_cattle",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from convective storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 2 events with data out of 9 total convective storm events (2005-2005)."
+          },
+          {
+            "id": "loss_006_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Mali. DesInventar records: 812 events with data out of 816 total drought events."
+          },
+          {
+            "id": "loss_007_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (DROUGHT) events in Mali. DesInventar records: 2 events with data out of 816 total drought events."
+          },
+          {
+            "id": "loss_008_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (DROUGHT) events in Mali. DesInventar records: 1 events with data out of 816 total drought events."
+          },
+          {
+            "id": "loss_009_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Mali. DesInventar records: 38 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_010_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Mali. DesInventar records: 115 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_011_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (FLOOD) events in Mali. DesInventar records: 6 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_012_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Mali. DesInventar records: 119 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_013_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Mali. DesInventar records: 14 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_014_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD) events in Mali. DesInventar records: 1 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_015_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Mali. DesInventar records: 143 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_016_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Mali. DesInventar records: 438 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_017_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Mali. DesInventar records: 99 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_018_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Mali. DesInventar records: 84 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_019_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (FLOOD) events in Mali. DesInventar records: 128 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_020_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLOOD) events in Mali. DesInventar records: 8 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_021_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Mali. DesInventar records: 23 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_022_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Mali. DesInventar records: 544 events with data out of 833 total flood events."
+          },
+          {
+            "id": "loss_023_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (WINDSTORM) events in Mali. DesInventar records: 1 events with data out of 2 total strong wind events."
+          },
+          {
+            "id": "loss_024_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (WINDSTORM) events in Mali. DesInventar records: 1 events with data out of 2 total strong wind events."
+          },
+          {
+            "id": "loss_025_strongwind_victims",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from strong wind (WINDSTORM) events in Mali. DesInventar records: 1 events with data out of 2 total strong wind events."
+          },
+          {
+            "id": "loss_026_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 2 events with data out of 58 total wildfire events (2008-2011)."
+          },
+          {
+            "id": "loss_027_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 41 events with data out of 58 total wildfire events (2008-2011)."
+          },
+          {
+            "id": "loss_028_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 2 events with data out of 58 total wildfire events (2008-2011)."
+          },
+          {
+            "id": "loss_029_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 2 events with data out of 58 total wildfire events (2008-2011)."
+          },
+          {
+            "id": "loss_030_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 3 events with data out of 58 total wildfire events (2008-2011)."
+          },
+          {
+            "id": "loss_031_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 5 events with data out of 58 total wildfire events (2008-2011)."
+          },
+          {
+            "id": "loss_032_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 1 events with data out of 58 total wildfire events (2008-2011)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-nerundrr_desinventar_a.json
+++ b/_datasets/json/rdls_lss-nerundrr_desinventar_a.json
@@ -1,0 +1,643 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-nerundrr_desinventar_a",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Niger",
+      "description": "National disaster loss inventory for Niger from the DesInventar Sendai Framework Monitor database, compiled by Systeme d'Alerte Precoce (SAP) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 1,362 event-level loss records covering historical, with observed impacts from drought, flood, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Niger from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Niger, maintained by Systeme d'Alerte Precoce (SAP). Covers 1,362 observed disaster events from historical. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "NER"
+        ],
+        "bbox": [
+          0.15,
+          11.7,
+          15.97,
+          23.52
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Niger",
+            "uri": "https://www.geonames.org/2440476/niger.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Systeme d'Alerte Precoce (SAP)",
+            "url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Niger maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Niger",
+          "url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853/resource/9b9d4019-129f-4df2-9499-09558b893bf8/download/niger.xlsx",
+          "access_url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853"
+        },
+        {
+          "id": "resource_002",
+          "title": "Niger.zip",
+          "description": "DesInventar disaster loss data for Niger",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853/resource/d6b6609d-3e6d-41f9-b14b-d6f4035d2d56/download/niger.zip",
+          "access_url": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Niger. DesInventar records: 46 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_002_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Niger. DesInventar records: 15 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_003_drought_deaths",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from drought (DROUGHT) events in Niger. DesInventar records: 2 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_004_drought_losses_local",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from drought (DROUGHT) events in Niger. DesInventar records: 6 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_005_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (DROUGHT) events in Niger. DesInventar records: 14 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_006_drought_relocated",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from drought (DROUGHT) events in Niger. DesInventar records: 10 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_007_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (DROUGHT) events in Niger. DesInventar records: 143 events with data out of 289 total drought events."
+          },
+          {
+            "id": "loss_008_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Niger. DesInventar records: 214 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_009_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Niger. DesInventar records: 239 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_010_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Niger. DesInventar records: 49 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_011_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Niger. DesInventar records: 5 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_012_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Niger. DesInventar records: 1 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_013_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Niger. DesInventar records: 29 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_014_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Niger. DesInventar records: 410 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_015_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Niger. DesInventar records: 34 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_016_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Niger. DesInventar records: 9 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_017_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLOOD) events in Niger. DesInventar records: 1 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_018_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (FLOOD) events in Niger. DesInventar records: 122 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_019_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Niger. DesInventar records: 2 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_020_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Niger. DesInventar records: 456 events with data out of 763 total flood events."
+          },
+          {
+            "id": "loss_021_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 78 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_022_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 168 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_023_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 23 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_024_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_025_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_026_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 28 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_027_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 14 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_028_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_029_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 14 events with data out of 310 total wildfire events."
+          },
+          {
+            "id": "loss_030_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 48 events with data out of 310 total wildfire events."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-nerundrr_desinventar_b.json
+++ b/_datasets/json/rdls_lss-nerundrr_desinventar_b.json
@@ -1,0 +1,643 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-nerundrr_desinventar_b",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Niger",
+      "description": "National disaster loss inventory for Niger from the DesInventar Sendai Framework Monitor database, compiled by Systeme d'Alerte Precoce (SAP) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 1,364 event-level loss records covering 1990-2013, with observed impacts from drought, flood, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Niger from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Niger, maintained by Systeme d'Alerte Precoce (SAP). Covers 1,364 observed disaster events from 1990-2013. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "NER"
+        ],
+        "bbox": [
+          0.15,
+          11.7,
+          15.97,
+          23.52
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Niger",
+            "uri": "https://www.geonames.org/2440476/niger.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Systeme d'Alerte Precoce (SAP)",
+            "url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Niger maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Niger",
+          "url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Niger",
+          "description": "Disaster data for Niger",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0/resource/326e9447-51ce-4041-8f1a-dddadaa04275/download/niger.zip",
+          "access_url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster tabular data for Niger",
+          "description": "Disaster tabular data for Niger",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0/resource/0f7c539d-baa5-403e-b049-01547f8bbd40/download/di_report-niger.xls",
+          "access_url": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_drought_affected",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from drought (DROUGHT) events in Niger. DesInventar records: 46 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_002_drought_damages_in_crops_ha",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from drought (DROUGHT) events in Niger. DesInventar records: 15 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_003_drought_deaths",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from drought (DROUGHT) events in Niger. DesInventar records: 2 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_004_drought_losses_local",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from drought (DROUGHT) events in Niger. DesInventar records: 6 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_005_drought_lost_cattle",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from drought (DROUGHT) events in Niger. DesInventar records: 14 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_006_drought_relocated",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from drought (DROUGHT) events in Niger. DesInventar records: 10 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_007_drought_victims",
+            "hazard_type": "drought",
+            "hazard_process": "meteorological_drought",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from drought (DROUGHT) events in Niger. DesInventar records: 143 events with data out of 289 total drought events (1998-2005)."
+          },
+          {
+            "id": "loss_008_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Niger. DesInventar records: 216 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_009_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Niger. DesInventar records: 239 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_010_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Niger. DesInventar records: 49 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_011_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Niger. DesInventar records: 5 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_012_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Niger. DesInventar records: 1 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_013_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Niger. DesInventar records: 29 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_014_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Niger. DesInventar records: 412 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_015_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Niger. DesInventar records: 34 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_016_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Niger. DesInventar records: 11 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_017_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLOOD) events in Niger. DesInventar records: 1 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_018_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (FLOOD) events in Niger. DesInventar records: 122 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_019_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Niger. DesInventar records: 2 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_020_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Niger. DesInventar records: 458 events with data out of 765 total flood events (1990-2012)."
+          },
+          {
+            "id": "loss_021_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 78 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_022_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 168 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_023_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 23 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_024_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_025_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_026_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 28 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_027_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 14 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_028_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_029_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 14 events with data out of 310 total wildfire events (1992-2013)."
+          },
+          {
+            "id": "loss_030_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 48 events with data out of 310 total wildfire events (1992-2013)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-senundrr_desinventar_a.json
+++ b/_datasets/json/rdls_lss-senundrr_desinventar_a.json
@@ -1,0 +1,625 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-senundrr_desinventar_a",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Senegal",
+      "description": "National disaster loss inventory for Senegal from the DesInventar Sendai Framework Monitor database, compiled by Direction de la Protection Civile (DPC) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 778 event-level loss records covering 1984-1992, with observed impacts from drought, flood, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Senegal from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Senegal, maintained by Direction de la Protection Civile (DPC). Covers 778 observed disaster events from 1984-1992. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "SEN"
+        ],
+        "bbox": [
+          -17.54,
+          12.31,
+          -11.38,
+          16.69
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Senegal",
+            "uri": "https://www.geonames.org/2245662/senegal.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Direction de la Protection Civile (DPC)",
+            "url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Senegal maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Senegal",
+          "url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb/resource/a93d352d-bd3f-4161-a471-8f015b89679b/download/senegal.xlsx",
+          "access_url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb"
+        },
+        {
+          "id": "resource_002",
+          "title": "Senegal.zip",
+          "description": "DesInventar disaster loss data for Senegal",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb/resource/688b6947-c44d-40bb-a9b0-46b4c5ae91d7/download/senegal.zip",
+          "access_url": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Senegal. DesInventar records: 18 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_002_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Senegal. DesInventar records: 14 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_003_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Senegal. DesInventar records: 22 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_004_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_005_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_006_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_007_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Senegal. DesInventar records: 45 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_008_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Senegal. DesInventar records: 8 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_009_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Senegal. DesInventar records: 12 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_010_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Senegal. DesInventar records: 3 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_011_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_012_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLOOD) events in Senegal. DesInventar records: 4 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_013_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Senegal. DesInventar records: 3 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_014_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Senegal. DesInventar records: 16 events with data out of 149 total flood events."
+          },
+          {
+            "id": "loss_015_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (STORM) events in Senegal. DesInventar records: 2 events with data out of 13 total strong wind events."
+          },
+          {
+            "id": "loss_016_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (STORM) events in Senegal. DesInventar records: 7 events with data out of 13 total strong wind events."
+          },
+          {
+            "id": "loss_017_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (STORM) events in Senegal. DesInventar records: 11 events with data out of 13 total strong wind events."
+          },
+          {
+            "id": "loss_018_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE) events in Senegal. DesInventar records: 4 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_019_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE) events in Senegal. DesInventar records: 1 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_020_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE) events in Senegal. DesInventar records: 50 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_021_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE) events in Senegal. DesInventar records: 17 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_022_wildfire_hospitals",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from wildfire (FIRE) events in Senegal. DesInventar records: 3 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_023_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE) events in Senegal. DesInventar records: 204 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_024_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE) events in Senegal. DesInventar records: 16 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_025_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE) events in Senegal. DesInventar records: 29 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_026_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE) events in Senegal. DesInventar records: 2 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_027_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (FIRE) events in Senegal. DesInventar records: 59 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_028_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE) events in Senegal. DesInventar records: 5 events with data out of 580 total wildfire events."
+          },
+          {
+            "id": "loss_029_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE) events in Senegal. DesInventar records: 25 events with data out of 580 total wildfire events."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-senundrr_desinventar_b.json
+++ b/_datasets/json/rdls_lss-senundrr_desinventar_b.json
@@ -1,0 +1,625 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-senundrr_desinventar_b",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Senegal",
+      "description": "National disaster loss inventory for Senegal from the DesInventar Sendai Framework Monitor database, compiled by Direction de la Protection Civile (DPC) and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 778 event-level loss records covering 1984-2014, with observed impacts from drought, flood, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Senegal from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Senegal, maintained by Direction de la Protection Civile (DPC). Covers 778 observed disaster events from 1984-2014. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "SEN"
+        ],
+        "bbox": [
+          -17.54,
+          12.31,
+          -11.38,
+          16.69
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Senegal",
+            "uri": "https://www.geonames.org/2245662/senegal.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Direction de la Protection Civile (DPC)",
+            "url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Senegal maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster loss and damage dataset for Senegal",
+          "url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Disaster data for Senegal",
+          "description": "Disaster data for Senegal",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a/resource/33a8ca9d-9c6a-429b-9e13-daf4588e4689/download/senegal.zip",
+          "access_url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a"
+        },
+        {
+          "id": "resource_002",
+          "title": "Disaster tabular data for Senegal",
+          "description": "Disaster tabular data for Senegal",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a/resource/7afd0d14-1561-4bd8-9d62-729fc2e6f6bf/download/di_report-senegal.xls",
+          "access_url": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (FLOOD) events in Senegal. DesInventar records: 18 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_002_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events in Senegal. DesInventar records: 14 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_003_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (FLOOD) events in Senegal. DesInventar records: 22 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_004_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_005_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_006_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_007_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (FLOOD) events in Senegal. DesInventar records: 45 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_008_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (FLOOD) events in Senegal. DesInventar records: 8 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_009_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (FLOOD) events in Senegal. DesInventar records: 12 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_010_flood_losses_local",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from flood (FLOOD) events in Senegal. DesInventar records: 3 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_011_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_012_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (FLOOD) events in Senegal. DesInventar records: 4 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_013_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (FLOOD) events in Senegal. DesInventar records: 3 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_014_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (FLOOD) events in Senegal. DesInventar records: 16 events with data out of 149 total flood events (2008-2010)."
+          },
+          {
+            "id": "loss_015_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (STORM) events in Senegal. DesInventar records: 2 events with data out of 13 total strong wind events (2013-2014)."
+          },
+          {
+            "id": "loss_016_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (STORM) events in Senegal. DesInventar records: 7 events with data out of 13 total strong wind events (2013-2014)."
+          },
+          {
+            "id": "loss_017_strongwind_missing",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from strong wind (STORM) events in Senegal. DesInventar records: 11 events with data out of 13 total strong wind events (2013-2014)."
+          },
+          {
+            "id": "loss_018_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (FIRE) events in Senegal. DesInventar records: 4 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_019_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (FIRE) events in Senegal. DesInventar records: 1 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_020_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (FIRE) events in Senegal. DesInventar records: 50 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_021_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (FIRE) events in Senegal. DesInventar records: 17 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_022_wildfire_hospitals",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from wildfire (FIRE) events in Senegal. DesInventar records: 3 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_023_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (FIRE) events in Senegal. DesInventar records: 204 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_024_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (FIRE) events in Senegal. DesInventar records: 16 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_025_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (FIRE) events in Senegal. DesInventar records: 29 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_026_wildfire_losses_local",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "XOF"
+            },
+            "description": "Observed total economic losses in local currency from wildfire (FIRE) events in Senegal. DesInventar records: 2 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_027_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (FIRE) events in Senegal. DesInventar records: 59 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_028_wildfire_lost_cattle",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from wildfire (FIRE) events in Senegal. DesInventar records: 5 events with data out of 580 total wildfire events (2010-2014)."
+          },
+          {
+            "id": "loss_029_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (FIRE) events in Senegal. DesInventar records: 25 events with data out of 580 total wildfire events (2010-2014)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/json/rdls_lss-tgoundrr_desinventar.json
+++ b/_datasets/json/rdls_lss-tgoundrr_desinventar.json
@@ -1,0 +1,1017 @@
+{
+  "datasets": [
+    {
+      "id": "rdls_lss-tgoundrr_desinventar",
+      "title": "DesInventar Disaster Loss and Damage Dataset for Togo",
+      "description": "National disaster loss inventory for Togo from the DesInventar Sendai Framework Monitor database, compiled by Comite National de Secours and published by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 391 event-level loss records covering 1960-2013, with observed impacts from convective_storm, flood, landslide, strong_wind, wildfire events. Loss data includes human casualties, displacement, building damage, economic losses, agricultural damage, and infrastructure impacts. [Source: This metadata record was automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a]",
+      "risk_data_type": [
+        "loss"
+      ],
+      "version": "1",
+      "purpose": "To document historical disaster losses in Togo from the DesInventar national disaster loss inventory, supporting disaster risk reduction monitoring under the Sendai Framework.",
+      "project": {
+        "name": "DesInventar Sendai - Disaster Information Management System",
+        "url": "https://www.desinventar.net/"
+      },
+      "details": "Event-level disaster loss records from the DesInventar database for Togo, maintained by Comite National de Secours. Covers 391 observed disaster events from 1960-2013. Data collected through direct observational reporting and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education centres, hospitals, roads), economic losses (local currency and USD), and agricultural impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal Data.",
+      "spatial": {
+        "scale": "national",
+        "countries": [
+          "TGO"
+        ],
+        "bbox": [
+          -0.17,
+          6.1,
+          1.78,
+          11.13
+        ],
+        "gazetteer_entries": [
+          {
+            "scheme": "GEONAMES",
+            "description": "Togo",
+            "uri": "https://www.geonames.org/2363686/togo.html",
+            "id": "gazetteer_1"
+          }
+        ]
+      },
+      "license": "CC-BY-4.0",
+      "attributions": [
+        {
+          "id": "attribution_publisher",
+          "role": "publisher",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.undrr.org/"
+          }
+        },
+        {
+          "id": "attribution_creator",
+          "role": "creator",
+          "entity": {
+            "name": "United Nations Office for Disaster Risk Reduction (UNDRR)",
+            "email": "isdr@un.org",
+            "url": "https://www.desinventar.net/"
+          }
+        },
+        {
+          "id": "attribution_contact",
+          "role": "contact_point",
+          "entity": {
+            "name": "Comite National de Secours",
+            "url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a"
+          }
+        }
+      ],
+      "sources": [
+        {
+          "id": "source_desinventar",
+          "name": "DesInventar Sendai",
+          "description": "National disaster loss database for Togo maintained using the DesInventar methodology.",
+          "url": "https://www.desinventar.net/",
+          "type": "dataset",
+          "component": "loss"
+        },
+        {
+          "id": "source_hdx",
+          "name": "Humanitarian Data Exchange (HDX)",
+          "description": "Dataset published on HDX: Disaster Loss Data for Togo",
+          "url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a",
+          "type": "dataset",
+          "component": "loss"
+        }
+      ],
+      "resources": [
+        {
+          "id": "hdx_dataset_metadata_json",
+          "title": "HDX dataset metadata (JSON)",
+          "description": "Dataset-level metadata exported from HDX.",
+          "data_format": "JSON (json)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a/download_metadata?format=json"
+        },
+        {
+          "id": "resource_001",
+          "title": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "description": "Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate change event",
+          "data_format": "Excel (xlsx)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a/resource/2d0ac135-1e71-4d2d-a2b5-e025406a5c08/download/togo.xlsx",
+          "access_url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a"
+        },
+        {
+          "id": "resource_002",
+          "title": "Togo.zip",
+          "description": "DesInventar disaster loss data for Togo",
+          "data_format": "Shapefile (shp)",
+          "access_modality": "file_download",
+          "download_url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a/resource/d6b85b8c-0b19-45e8-a6d8-9133b33c9be0/download/togo.zip",
+          "access_url": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a"
+        }
+      ],
+      "loss": {
+        "losses": [
+          {
+            "id": "loss_001_convectivestorm_affected",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from convective storm (Thunderstorm) events in Togo. DesInventar records: 2 events with data out of 9 total convective storm events (2011-2011)."
+          },
+          {
+            "id": "loss_002_convectivestorm_deaths",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from convective storm (Thunderstorm) events in Togo. DesInventar records: 1 events with data out of 9 total convective storm events (2011-2011)."
+          },
+          {
+            "id": "loss_003_convectivestorm_education_centers",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from convective storm (Thunderstorm) events in Togo. DesInventar records: 6 events with data out of 9 total convective storm events (2011-2011)."
+          },
+          {
+            "id": "loss_004_convectivestorm_houses_damaged",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from convective storm (Thunderstorm) events in Togo. DesInventar records: 4 events with data out of 9 total convective storm events (2011-2011)."
+          },
+          {
+            "id": "loss_005_convectivestorm_houses_destroyed",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from convective storm (Thunderstorm) events in Togo. DesInventar records: 2 events with data out of 9 total convective storm events (2011-2011)."
+          },
+          {
+            "id": "loss_006_convectivestorm_losses_usd",
+            "hazard_type": "convective_storm",
+            "hazard_process": "tornado",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from convective storm (Thunderstorm) events in Togo. DesInventar records: 1 events with data out of 9 total convective storm events (2011-2011)."
+          },
+          {
+            "id": "loss_007_flood_affected",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from flood (Flood) events in Togo. DesInventar records: 109 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_008_flood_damages_in_crops_ha",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from flood (Flood) events in Togo. DesInventar records: 21 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_009_flood_damages_in_roads_mts",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed metres of transport networks destroyed from flood (Flood) events in Togo. DesInventar records: 4 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_010_flood_deaths",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from flood (Flood) events in Togo. DesInventar records: 32 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_011_flood_education_centers",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from flood (Flood) events in Togo. DesInventar records: 15 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_012_flood_evacuated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from flood (Flood) events in Togo. DesInventar records: 11 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_013_flood_hospitals",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from flood (Flood) events in Togo. DesInventar records: 2 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_014_flood_houses_damaged",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from flood (Flood) events in Togo. DesInventar records: 54 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_015_flood_houses_destroyed",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from flood (Flood) events in Togo. DesInventar records: 59 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_016_flood_injured",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from flood (Flood) events in Togo. DesInventar records: 22 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_017_flood_losses_usd",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from flood (Flood) events in Togo. DesInventar records: 30 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_018_flood_lost_cattle",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from flood (Flood) events in Togo. DesInventar records: 1 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_019_flood_missing",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons missing or unaccounted for after disaster events from flood (Flood) events in Togo. DesInventar records: 2 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_020_flood_relocated",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from flood (Flood) events in Togo. DesInventar records: 32 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_021_flood_victims",
+            "hazard_type": "flood",
+            "hazard_process": "fluvial_flood",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from flood (Flood) events in Togo. DesInventar records: 16 events with data out of 135 total flood events."
+          },
+          {
+            "id": "loss_022_landslide_affected",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from landslide (Landslide) events in Togo. DesInventar records: 5 events with data out of 6 total landslide events."
+          },
+          {
+            "id": "loss_023_landslide_deaths",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from landslide (Landslide) events in Togo. DesInventar records: 1 events with data out of 6 total landslide events."
+          },
+          {
+            "id": "loss_024_landslide_evacuated",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from landslide (Landslide) events in Togo. DesInventar records: 1 events with data out of 6 total landslide events."
+          },
+          {
+            "id": "loss_025_landslide_houses_damaged",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from landslide (Landslide) events in Togo. DesInventar records: 5 events with data out of 6 total landslide events."
+          },
+          {
+            "id": "loss_026_landslide_houses_destroyed",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from landslide (Landslide) events in Togo. DesInventar records: 5 events with data out of 6 total landslide events."
+          },
+          {
+            "id": "loss_027_landslide_victims",
+            "hazard_type": "landslide",
+            "hazard_process": "landslide_general",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from landslide (Landslide) events in Togo. DesInventar records: 5 events with data out of 6 total landslide events."
+          },
+          {
+            "id": "loss_028_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (Storm) events in Togo. DesInventar records: 4 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_029_strongwind_education_centers",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from strong wind (Storm) events in Togo. DesInventar records: 1 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_030_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (Storm) events in Togo. DesInventar records: 1 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_031_strongwind_losses_usd",
+            "hazard_type": "strong_wind",
+            "hazard_process": "extratropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from strong wind (Storm) events in Togo. DesInventar records: 2 events with data out of 4 total strong wind events."
+          },
+          {
+            "id": "loss_032_strongwind_affected",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from strong wind (Hurricane) events in Togo. DesInventar records: 20 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_033_strongwind_deaths",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_034_strongwind_education_centers",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from strong wind (Hurricane) events in Togo. DesInventar records: 14 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_035_strongwind_evacuated",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_036_strongwind_hospitals",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed health facilities destroyed or affected from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_037_strongwind_houses_damaged",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from strong wind (Hurricane) events in Togo. DesInventar records: 14 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_038_strongwind_houses_destroyed",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from strong wind (Hurricane) events in Togo. DesInventar records: 5 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_039_strongwind_injured",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from strong wind (Hurricane) events in Togo. DesInventar records: 3 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_040_strongwind_losses_usd",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from strong wind (Hurricane) events in Togo. DesInventar records: 7 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_041_strongwind_lost_cattle",
+            "hazard_type": "strong_wind",
+            "hazard_process": "tropical_cyclone",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed livestock lost from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with data out of 40 total strong wind events (1960-2013)."
+          },
+          {
+            "id": "loss_042_wildfire_affected",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons indirectly affected (disruption to services, commerce, work) from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 162 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_043_wildfire_damages_in_crops_ha",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "agriculture",
+            "asset_dimension": "product",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "area",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed hectares of crops/woods destroyed or affected from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 14 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_044_wildfire_deaths",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed deaths directly caused by disaster events from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 13 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_045_wildfire_education_centers",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "infrastructure",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed educational facilities destroyed or affected from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 9 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_046_wildfire_evacuated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons temporarily evacuated from homes or workplaces from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 4 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_047_wildfire_houses_damaged",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "damage_ratio",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes with non-structural damage, still habitable from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 50 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_048_wildfire_houses_destroyed",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "structure",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "asset_loss",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed homes destroyed beyond habitability from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 64 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_049_wildfire_injured",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "casualty_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons injured or made sick directly by disaster events from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 7 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_050_wildfire_losses_usd",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "buildings",
+            "asset_dimension": "content",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "economic_loss_value",
+              "quantity_kind": "currency",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical",
+              "currency": "USD"
+            },
+            "description": "Observed total economic losses in US Dollars from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 74 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_051_wildfire_relocated",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "displaced_count",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons permanently relocated from homes from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 12 events with data out of 197 total wildfire events (2009-2009)."
+          },
+          {
+            "id": "loss_052_wildfire_victims",
+            "hazard_type": "wildfire",
+            "hazard_process": "wildfire",
+            "asset_category": "population",
+            "asset_dimension": "population",
+            "impact_and_losses": {
+              "impact_type": "direct",
+              "impact_modelling": "observed",
+              "impact_metric": "exposure_to_hazard",
+              "quantity_kind": "count",
+              "loss_type": "ground_up",
+              "loss_approach": "empirical",
+              "loss_frequency_type": "empirical"
+            },
+            "description": "Observed persons whose goods/services suffered serious damage from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 10 events with data out of 197 total wildfire events (2009-2009)."
+          }
+        ]
+      },
+      "links": [
+        {
+          "href": "https://docs.riskdatalibrary.org/en/0__3__0/rdls_schema.json",
+          "rel": "describedby"
+        },
+        {
+          "href": "https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a",
+          "rel": "source"
+        }
+      ]
+    }
+  ]
+}

--- a/_datasets/rdls_lss-albundrr_desinventar.md
+++ b/_datasets/rdls_lss-albundrr_desinventar.md
@@ -1,0 +1,378 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: General Directorate of Civil Emergencies
+  url: 'More information can be found here: http://www.mbrojtjacivile.al/'
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-albundrr_desinventar
+description: 'National disaster loss inventory for Albania from the DesInventar Sendai
+  Framework Monitor database, compiled by General Directorate of Civil Emergencies
+  and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 4,659 event-level loss records covering 1973-2015, with observed impacts
+  from coastal_flood, convective_storm, drought, earthquake, extreme_temperature,
+  flood, landslide, strong_wind, wildfire events. Loss data includes human casualties,
+  displacement, building damage, economic losses, agricultural damage, and infrastructure
+  impacts. [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e]'
+details: 'Event-level disaster loss records from the DesInventar database for Albania,
+  maintained by General Directorate of Civil Emergencies. Covers 4,659 observed disaster
+  events from 1973-2015. Data collected through direct observational reporting and
+  includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from convective
+    storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 54 events
+    with data out of 217 total convective storm events (1976-2014)., Observed deaths
+    directly caused by disaster events from earthquake (EARTHQUAKE) events in Albania.
+    DesInventar records: 14 events with data out of 185 total earthquake events (2014-2014).,
+    Observed deaths directly caused by disaster events from extreme temperature (COLD
+    WAVE, FROST) events in Albania. DesInventar records: 10 events with data out of
+    126 total extreme temperature events (1990-2012)., Observed deaths directly caused
+    by disaster events from extreme temperature (HEAT WAVE) events in Albania. DesInventar
+    records: 9 events with data out of 22 total extreme temperature events (1998-2002).,
+    Observed deaths directly caused by disaster events from flood (FLASH FLOOD, FLOOD)
+    events in Albania. DesInventar records: 44 events with data out of 949 total flood
+    events (2002-2015)., Observed deaths directly caused by disaster events from flood
+    (RAINS) events in Albania. DesInventar records: 3 events with data out of 217
+    total flood events (2007-2013)., Observed deaths directly caused by disaster events
+    from landslide (AVALANCHE) events in Albania. DesInventar records: 17 events with
+    data out of 25 total landslide events (2010-2012)., Observed deaths directly caused
+    by disaster events from landslide (LANDSLIDE) events in Albania. DesInventar records:
+    40 events with data out of 629 total landslide events (1995-2013)., Observed deaths
+    directly caused by disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM)
+    events in Albania. DesInventar records: 45 events with data out of 891 total strong
+    wind events (1973-2012)., Observed deaths directly caused by disaster events from
+    wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 13 events
+    with data out of 1,383 total wildfire events (2003-2014)., Observed educational
+    facilities destroyed or affected from earthquake (EARTHQUAKE) events in Albania.
+    DesInventar records: 8 events with data out of 185 total earthquake events (2014-2014).,
+    Observed educational facilities destroyed or affected from flood (FLASH FLOOD,
+    FLOOD) events in Albania. DesInventar records: 13 events with data out of 949
+    total flood events (2002-2015)., Observed educational facilities destroyed or
+    affected from flood (RAINS) events in Albania. DesInventar records: 2 events with
+    data out of 217 total flood events (2007-2013)., Observed educational facilities
+    destroyed or affected from landslide (LANDSLIDE) events in Albania. DesInventar
+    records: 7 events with data out of 629 total landslide events (1995-2013)., Observed
+    educational facilities destroyed or affected from strong wind (SNOWSTORM, STORM,
+    WINDSTORM) events in Albania. DesInventar records: 28 events with data out of
+    891 total strong wind events (1973-2012)., Observed educational facilities destroyed
+    or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records:
+    1 events with data out of 1,383 total wildfire events (2003-2014)., Observed health
+    facilities destroyed or affected from earthquake (EARTHQUAKE) events in Albania.
+    DesInventar records: 5 events with data out of 185 total earthquake events (2014-2014).,
+    Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD)
+    events in Albania. DesInventar records: 2 events with data out of 949 total flood
+    events (2002-2015)., Observed health facilities destroyed or affected from strong
+    wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 1 events
+    with data out of 891 total strong wind events (1973-2012)., Observed health facilities
+    destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar
+    records: 1 events with data out of 1,383 total wildfire events (2003-2014)., Observed
+    hectares of crops/woods destroyed or affected from convective storm (HAILSTORM,
+    THUNDERSTORM) events in Albania. DesInventar records: 79 events with data out
+    of 217 total convective storm events (1976-2014)., Observed hectares of crops/woods
+    destroyed or affected from drought (DROUGHT) events in Albania. DesInventar records:
+    1 events with data out of 1 total drought events (1993-1993)., Observed hectares
+    of crops/woods destroyed or affected from extreme temperature (COLD WAVE, FROST)
+    events in Albania. DesInventar records: 55 events with data out of 126 total extreme
+    temperature events (1990-2012)., Observed hectares of crops/woods destroyed or
+    affected from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records:
+    474 events with data out of 949 total flood events (2002-2015)., Observed hectares
+    of crops/woods destroyed or affected from flood (RAINS) events in Albania. DesInventar
+    records: 49 events with data out of 217 total flood events (2007-2013)., Observed
+    hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events
+    in Albania. DesInventar records: 17 events with data out of 629 total landslide
+    events (1995-2013)., Observed hectares of crops/woods destroyed or affected from
+    landslide (SEDIMENTATION) events in Albania. DesInventar records: 2 events with
+    data out of 3 total landslide events (1999-2005)., Observed hectares of crops/woods
+    destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in
+    Albania. DesInventar records: 50 events with data out of 891 total strong wind
+    events (1973-2012)., Observed hectares of crops/woods destroyed or affected from
+    wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 716 events
+    with data out of 1,383 total wildfire events (2003-2014)., Observed homes destroyed
+    beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in
+    Albania. DesInventar records: 2 events with data out of 217 total convective storm
+    events (1976-2014)., Observed homes destroyed beyond habitability from earthquake
+    (EARTHQUAKE) events in Albania. DesInventar records: 66 events with data out of
+    185 total earthquake events (2014-2014)., Observed homes destroyed beyond habitability
+    from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 96 events
+    with data out of 949 total flood events (2002-2015)., Observed homes destroyed
+    beyond habitability from flood (RAINS) events in Albania. DesInventar records:
+    43 events with data out of 217 total flood events (2007-2013)., Observed homes
+    destroyed beyond habitability from landslide (AVALANCHE) events in Albania. DesInventar
+    records: 3 events with data out of 25 total landslide events (2010-2012)., Observed
+    homes destroyed beyond habitability from landslide (LANDSLIDE) events in Albania.
+    DesInventar records: 346 events with data out of 629 total landslide events (1995-2013).,
+    Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM,
+    WINDSTORM) events in Albania. DesInventar records: 108 events with data out of
+    891 total strong wind events (1973-2012)., Observed homes destroyed beyond habitability
+    from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 46 events
+    with data out of 1,383 total wildfire events (2003-2014)., Observed homes with
+    non-structural damage, still habitable from coastal flood (SURGE) events in Albania.
+    DesInventar records: 2 events with data out of 7 total coastal flood events (1975-2012).,
+    Observed homes with non-structural damage, still habitable from convective storm
+    (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 2 events with
+    data out of 217 total convective storm events (1976-2014)., Observed homes with
+    non-structural damage, still habitable from earthquake (EARTHQUAKE) events in
+    Albania. DesInventar records: 92 events with data out of 185 total earthquake
+    events (2014-2014)., Observed homes with non-structural damage, still habitable
+    from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records:
+    2 events with data out of 126 total extreme temperature events (1990-2012)., Observed
+    homes with non-structural damage, still habitable from flood (FLASH FLOOD, FLOOD)
+    events in Albania. DesInventar records: 208 events with data out of 949 total
+    flood events (2002-2015)., Observed homes with non-structural damage, still habitable
+    from flood (RAINS) events in Albania. DesInventar records: 40 events with data
+    out of 217 total flood events (2007-2013)., Observed homes with non-structural
+    damage, still habitable from landslide (AVALANCHE) events in Albania. DesInventar
+    records: 3 events with data out of 25 total landslide events (2010-2012)., Observed
+    homes with non-structural damage, still habitable from landslide (LANDSLIDE) events
+    in Albania. DesInventar records: 117 events with data out of 629 total landslide
+    events (1995-2013)., Observed homes with non-structural damage, still habitable
+    from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
+    records: 86 events with data out of 891 total strong wind events (1973-2012).,
+    Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+    FOREST FIRE) events in Albania. DesInventar records: 60 events with data out of
+    1,383 total wildfire events (2003-2014)., Observed livestock lost from convective
+    storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 18 events
+    with data out of 217 total convective storm events (1976-2014)., Observed livestock
+    lost from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar
+    records: 10 events with data out of 126 total extreme temperature events (1990-2012).,
+    Observed livestock lost from extreme temperature (HEAT WAVE) events in Albania.
+    DesInventar records: 1 events with data out of 22 total extreme temperature events
+    (1998-2002)., Observed livestock lost from flood (FLASH FLOOD, FLOOD) events in
+    Albania. DesInventar records: 96 events with data out of 949 total flood events
+    (2002-2015)., Observed livestock lost from flood (RAINS) events in Albania. DesInventar
+    records: 3 events with data out of 217 total flood events (2007-2013)., Observed
+    livestock lost from landslide (AVALANCHE) events in Albania. DesInventar records:
+    3 events with data out of 25 total landslide events (2010-2012)., Observed livestock
+    lost from landslide (LANDSLIDE) events in Albania. DesInventar records: 3 events
+    with data out of 629 total landslide events (1995-2013)., Observed livestock lost
+    from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
+    records: 65 events with data out of 891 total strong wind events (1973-2012).,
+    Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar
+    records: 11 events with data out of 1,383 total wildfire events (2003-2014).,
+    Observed metres of transport networks destroyed from earthquake (EARTHQUAKE) events
+    in Albania. DesInventar records: 1 events with data out of 185 total earthquake
+    events (2014-2014)., Observed metres of transport networks destroyed from flood
+    (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 19 events with data
+    out of 949 total flood events (2002-2015)., Observed metres of transport networks
+    destroyed from flood (RAINS) events in Albania. DesInventar records: 4 events
+    with data out of 217 total flood events (2007-2013)., Observed metres of transport
+    networks destroyed from landslide (LANDSLIDE) events in Albania. DesInventar records:
+    30 events with data out of 629 total landslide events (1995-2013)., Observed metres
+    of transport networks destroyed from strong wind (SNOWSTORM, STORM, WINDSTORM)
+    events in Albania. DesInventar records: 4 events with data out of 891 total strong
+    wind events (1973-2012)., Observed persons indirectly affected (disruption to
+    services, commerce, work) from earthquake (EARTHQUAKE) events in Albania. DesInventar
+    records: 8 events with data out of 185 total earthquake events (2014-2014)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from flood
+    (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 18 events with data
+    out of 949 total flood events (2002-2015)., Observed persons indirectly affected
+    (disruption to services, commerce, work) from flood (RAINS) events in Albania.
+    DesInventar records: 1 events with data out of 217 total flood events (2007-2013).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from landslide (LANDSLIDE) events in Albania. DesInventar records: 5 events with
+    data out of 629 total landslide events (1995-2013)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from strong wind (SNOWSTORM,
+    STORM, WINDSTORM) events in Albania. DesInventar records: 55 events with data
+    out of 891 total strong wind events (1973-2012)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST
+    FIRE) events in Albania. DesInventar records: 4 events with data out of 1,383
+    total wildfire events (2003-2014)., Observed persons injured or made sick directly
+    by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Albania.
+    DesInventar records: 19 events with data out of 217 total convective storm events
+    (1976-2014)., Observed persons injured or made sick directly by disaster events
+    from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 18 events
+    with data out of 185 total earthquake events (2014-2014)., Observed persons injured
+    or made sick directly by disaster events from extreme temperature (COLD WAVE,
+    FROST) events in Albania. DesInventar records: 10 events with data out of 126
+    total extreme temperature events (1990-2012)., Observed persons injured or made
+    sick directly by disaster events from extreme temperature (HEAT WAVE) events in
+    Albania. DesInventar records: 11 events with data out of 22 total extreme temperature
+    events (1998-2002)., Observed persons injured or made sick directly by disaster
+    events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records:
+    18 events with data out of 949 total flood events (2002-2015)., Observed persons
+    injured or made sick directly by disaster events from flood (RAINS) events in
+    Albania. DesInventar records: 2 events with data out of 217 total flood events
+    (2007-2013)., Observed persons injured or made sick directly by disaster events
+    from landslide (AVALANCHE) events in Albania. DesInventar records: 8 events with
+    data out of 25 total landslide events (2010-2012)., Observed persons injured or
+    made sick directly by disaster events from landslide (LANDSLIDE) events in Albania.
+    DesInventar records: 15 events with data out of 629 total landslide events (1995-2013).,
+    Observed persons injured or made sick directly by disaster events from strong
+    wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 26
+    events with data out of 891 total strong wind events (1973-2012)., Observed persons
+    injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE)
+    events in Albania. DesInventar records: 6 events with data out of 1,383 total
+    wildfire events (2003-2014)., Observed persons missing or unaccounted for after
+    disaster events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar
+    records: 1 events with data out of 949 total flood events (2002-2015)., Observed
+    persons missing or unaccounted for after disaster events from flood (RAINS) events
+    in Albania. DesInventar records: 1 events with data out of 217 total flood events
+    (2007-2013)., Observed persons missing or unaccounted for after disaster events
+    from landslide (AVALANCHE) events in Albania. DesInventar records: 2 events with
+    data out of 25 total landslide events (2010-2012)., Observed persons missing or
+    unaccounted for after disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM)
+    events in Albania. DesInventar records: 4 events with data out of 891 total strong
+    wind events (1973-2012)., Observed persons permanently relocated from homes from
+    flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 4 events with
+    data out of 949 total flood events (2002-2015)., Observed persons permanently
+    relocated from homes from landslide (LANDSLIDE) events in Albania. DesInventar
+    records: 5 events with data out of 629 total landslide events (1995-2013)., Observed
+    persons permanently relocated from homes from wildfire (FIRE, FOREST FIRE) events
+    in Albania. DesInventar records: 5 events with data out of 1,383 total wildfire
+    events (2003-2014)., Observed persons temporarily evacuated from homes or workplaces
+    from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 5 events
+    with data out of 185 total earthquake events (2014-2014)., Observed persons temporarily
+    evacuated from homes or workplaces from flood (FLASH FLOOD, FLOOD) events in Albania.
+    DesInventar records: 76 events with data out of 949 total flood events (2002-2015).,
+    Observed persons temporarily evacuated from homes or workplaces from flood (RAINS)
+    events in Albania. DesInventar records: 2 events with data out of 217 total flood
+    events (2007-2013)., Observed persons temporarily evacuated from homes or workplaces
+    from landslide (LANDSLIDE) events in Albania. DesInventar records: 29 events with
+    data out of 629 total landslide events (1995-2013)., Observed persons temporarily
+    evacuated from homes or workplaces from strong wind (SNOWSTORM, STORM, WINDSTORM)
+    events in Albania. DesInventar records: 16 events with data out of 891 total strong
+    wind events (1973-2012)., Observed persons temporarily evacuated from homes or
+    workplaces from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records:
+    5 events with data out of 1,383 total wildfire events (2003-2014)., Observed persons
+    whose goods/services suffered serious damage from convective storm (HAILSTORM,
+    THUNDERSTORM) events in Albania. DesInventar records: 1 events with data out of
+    217 total convective storm events (1976-2014)., Observed persons whose goods/services
+    suffered serious damage from earthquake (EARTHQUAKE) events in Albania. DesInventar
+    records: 26 events with data out of 185 total earthquake events (2014-2014).,
+    Observed persons whose goods/services suffered serious damage from earthquake
+    (LIQUEFACTION) events in Albania. DesInventar records: 2 events with data out
+    of 4 total earthquake events (2014-2014)., Observed persons whose goods/services
+    suffered serious damage from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar
+    records: 129 events with data out of 949 total flood events (2002-2015)., Observed
+    persons whose goods/services suffered serious damage from flood (RAINS) events
+    in Albania. DesInventar records: 42 events with data out of 217 total flood events
+    (2007-2013)., Observed persons whose goods/services suffered serious damage from
+    landslide (AVALANCHE) events in Albania. DesInventar records: 1 events with data
+    out of 25 total landslide events (2010-2012)., Observed persons whose goods/services
+    suffered serious damage from landslide (LANDSLIDE) events in Albania. DesInventar
+    records: 249 events with data out of 629 total landslide events (1995-2013).,
+    Observed persons whose goods/services suffered serious damage from strong wind
+    (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 88 events
+    with data out of 891 total strong wind events (1973-2012)., Observed persons whose
+    goods/services suffered serious damage from wildfire (FIRE, FOREST FIRE) events
+    in Albania. DesInventar records: 37 events with data out of 1,383 total wildfire
+    events (2003-2014)., Observed total economic losses in US Dollars from flood (FLASH
+    FLOOD, FLOOD) events in Albania. DesInventar records: 4 events with data out of
+    949 total flood events (2002-2015)., Observed total economic losses in US Dollars
+    from landslide (LANDSLIDE) events in Albania. DesInventar records: 1 events with
+    data out of 629 total landslide events (1995-2013)., Observed total economic losses
+    in US Dollars from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar
+    records: 23 events with data out of 1,383 total wildfire events (2003-2014).,
+    Observed total economic losses in local currency from convective storm (HAILSTORM,
+    THUNDERSTORM) events in Albania. DesInventar records: 20 events with data out
+    of 217 total convective storm events (1976-2014)., Observed total economic losses
+    in local currency from earthquake (EARTHQUAKE) events in Albania. DesInventar
+    records: 78 events with data out of 185 total earthquake events (2014-2014).,
+    Observed total economic losses in local currency from extreme temperature (COLD
+    WAVE, FROST) events in Albania. DesInventar records: 5 events with data out of
+    126 total extreme temperature events (1990-2012)., Observed total economic losses
+    in local currency from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar
+    records: 225 events with data out of 949 total flood events (2002-2015)., Observed
+    total economic losses in local currency from flood (RAINS) events in Albania.
+    DesInventar records: 57 events with data out of 217 total flood events (2007-2013).,
+    Observed total economic losses in local currency from landslide (AVALANCHE) events
+    in Albania. DesInventar records: 2 events with data out of 25 total landslide
+    events (2010-2012)., Observed total economic losses in local currency from landslide
+    (LANDSLIDE) events in Albania. DesInventar records: 306 events with data out of
+    629 total landslide events (1995-2013)., Observed total economic losses in local
+    currency from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
+    records: 130 events with data out of 891 total strong wind events (1973-2012).,
+    Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE)
+    events in Albania. DesInventar records: 65 events with data out of 1,383 total
+    wildfire events (2003-2014).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, extreme_cold, extreme_heat, fluvial_flood,
+    ground_motion, landslide_general, landslide_mudflow, liquefaction, meteorological_drought,
+    pluvial_flood, snow_avalanche, storm_surge, tornado, wildfire
+  hazard_type: coastal_flood, convective_storm, drought, earthquake, extreme_temperature,
+    flood, landslide, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Albania from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Albania
+  download_url: https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e/resource/6850c4bf-cceb-4975-8716-8a5108ad82c3/download/albania.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Albania
+- coordinate_system: null
+  description: Disaster Tabular data for Albania
+  download_url: https://data.humdata.org/dataset/01c902dd-fec3-499b-a6c0-d092c18bc73e/resource/0d9d729f-658c-4e7d-bbf7-f2558e8a9715/download/di_report-albania.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster Tabular data for Albania
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-albundrr_desinventar
+spatial:
+  bbox:
+  - 19.27
+  - 39.64
+  - 21.04
+  - 42.65
+  countries:
+  - ALB
+  gazetteer_entries:
+  - description: Albania
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/783754/albania.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Albania
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-colundrr_desinventar.md
+++ b/_datasets/rdls_lss-colundrr_desinventar.md
@@ -1,0 +1,433 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Corporacion OSSO / La Red
+  url: https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-colundrr_desinventar
+description: 'National disaster loss inventory for Colombia from the DesInventar Sendai
+  Framework Monitor database, compiled by Corporacion OSSO / La Red and published
+  by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 28,916
+  event-level loss records covering 1963-2013, with observed impacts from coastal_flood,
+  convective_storm, drought, earthquake, extreme_temperature, flood, landslide, strong_wind,
+  tsunami, wildfire events. Loss data includes human casualties, displacement, building
+  damage, economic losses, agricultural damage, and infrastructure impacts. [Source:
+  This metadata record was automatically extracted from the Humanitarian Data Exchange
+  (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79]'
+details: 'Event-level disaster loss records from the DesInventar database for Colombia,
+  maintained by Corporacion OSSO / La Red. Covers 28,916 observed disaster events
+  from 1963-2013. Data collected through direct observational reporting and includes
+  human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical
+  impacts (houses destroyed/damaged, education centres, hospitals, roads), economic
+  losses (local currency and USD), and agricultural impacts (crop damage in hectares,
+  livestock losses). Methodology: Direct Observational Data / Anecdotal Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from coastal flood
+    (SURGE) events in Colombia. DesInventar records: 18 events with data out of 159
+    total coastal flood events (1984-2013)., Observed deaths directly caused by disaster
+    events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 144
+    events with data out of 888 total earthquake events (1986-2013)., Observed deaths
+    directly caused by disaster events from flood (FLOOD) events in Colombia. DesInventar
+    records: 756 events with data out of 15,109 total flood events (1984-2013)., Observed
+    deaths directly caused by disaster events from landslide (AVALANCHE) events in
+    Colombia. DesInventar records: 3 events with data out of 25 total landslide events
+    (1995-2009)., Observed deaths directly caused by disaster events from landslide
+    (LANDSLIDE) events in Colombia. DesInventar records: 1,409 events with data out
+    of 9,041 total landslide events (1984-2013)., Observed deaths directly caused
+    by disaster events from strong wind (HURRICANE) events in Colombia. DesInventar
+    records: 3 events with data out of 7 total strong wind events (1963-1988)., Observed
+    deaths directly caused by disaster events from strong wind (SNOWSTORM, STORM)
+    events in Colombia. DesInventar records: 75 events with data out of 348 total
+    strong wind events (1976-2013)., Observed deaths directly caused by disaster events
+    from tsunami (TSUNAMI) events in Colombia. DesInventar records: 4 events with
+    data out of 5 total tsunami events (1979-1979)., Observed deaths directly caused
+    by disaster events from wildfire (FIRE) events in Colombia. DesInventar records:
+    274 events with data out of 2,588 total wildfire events (1984-2013)., Observed
+    educational facilities destroyed or affected from coastal flood (SURGE) events
+    in Colombia. DesInventar records: 2 events with data out of 159 total coastal
+    flood events (1984-2013)., Observed educational facilities destroyed or affected
+    from convective storm (HAILSTORM) events in Colombia. DesInventar records: 4 events
+    with data out of 81 total convective storm events (1989-2013)., Observed educational
+    facilities destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar
+    records: 1 events with data out of 591 total drought events (1985-2012)., Observed
+    educational facilities destroyed or affected from earthquake (EARTHQUAKE) events
+    in Colombia. DesInventar records: 146 events with data out of 888 total earthquake
+    events (1986-2013)., Observed educational facilities destroyed or affected from
+    flood (FLOOD) events in Colombia. DesInventar records: 455 events with data out
+    of 15,109 total flood events (1984-2013)., Observed educational facilities destroyed
+    or affected from landslide (AVALANCHE) events in Colombia. DesInventar records:
+    2 events with data out of 25 total landslide events (1995-2009)., Observed educational
+    facilities destroyed or affected from landslide (LANDSLIDE) events in Colombia.
+    DesInventar records: 262 events with data out of 9,041 total landslide events
+    (1984-2013)., Observed educational facilities destroyed or affected from strong
+    wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 17 events with
+    data out of 348 total strong wind events (1976-2013)., Observed educational facilities
+    destroyed or affected from wildfire (FIRE) events in Colombia. DesInventar records:
+    27 events with data out of 2,588 total wildfire events (1984-2013)., Observed
+    health facilities destroyed or affected from coastal flood (SURGE) events in Colombia.
+    DesInventar records: 1 events with data out of 159 total coastal flood events
+    (1984-2013)., Observed health facilities destroyed or affected from convective
+    storm (HAILSTORM) events in Colombia. DesInventar records: 2 events with data
+    out of 81 total convective storm events (1989-2013)., Observed health facilities
+    destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar records:
+    1 events with data out of 591 total drought events (1985-2012)., Observed health
+    facilities destroyed or affected from earthquake (EARTHQUAKE) events in Colombia.
+    DesInventar records: 46 events with data out of 888 total earthquake events (1986-2013).,
+    Observed health facilities destroyed or affected from flood (FLOOD) events in
+    Colombia. DesInventar records: 88 events with data out of 15,109 total flood events
+    (1984-2013)., Observed health facilities destroyed or affected from landslide
+    (LANDSLIDE) events in Colombia. DesInventar records: 34 events with data out of
+    9,041 total landslide events (1984-2013)., Observed health facilities destroyed
+    or affected from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar
+    records: 5 events with data out of 348 total strong wind events (1976-2013).,
+    Observed health facilities destroyed or affected from tsunami (TSUNAMI) events
+    in Colombia. DesInventar records: 1 events with data out of 5 total tsunami events
+    (1979-1979)., Observed health facilities destroyed or affected from wildfire (FIRE)
+    events in Colombia. DesInventar records: 14 events with data out of 2,588 total
+    wildfire events (1984-2013)., Observed hectares of crops/woods destroyed or affected
+    from coastal flood (SURGE) events in Colombia. DesInventar records: 1 events with
+    data out of 159 total coastal flood events (1984-2013)., Observed hectares of
+    crops/woods destroyed or affected from convective storm (HAILSTORM) events in
+    Colombia. DesInventar records: 6 events with data out of 81 total convective storm
+    events (1989-2013)., Observed hectares of crops/woods destroyed or affected from
+    drought (DROUGHT) events in Colombia. DesInventar records: 25 events with data
+    out of 591 total drought events (1985-2012)., Observed hectares of crops/woods
+    destroyed or affected from earthquake (EARTHQUAKE) events in Colombia. DesInventar
+    records: 1 events with data out of 888 total earthquake events (1986-2013)., Observed
+    hectares of crops/woods destroyed or affected from extreme temperature (FROST)
+    events in Colombia. DesInventar records: 20 events with data out of 62 total extreme
+    temperature events (1985-2013)., Observed hectares of crops/woods destroyed or
+    affected from flood (FLOOD) events in Colombia. DesInventar records: 1,015 events
+    with data out of 15,109 total flood events (1984-2013)., Observed hectares of
+    crops/woods destroyed or affected from landslide (AVALANCHE) events in Colombia.
+    DesInventar records: 1 events with data out of 25 total landslide events (1995-2009).,
+    Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
+    events in Colombia. DesInventar records: 212 events with data out of 9,041 total
+    landslide events (1984-2013)., Observed hectares of crops/woods destroyed or affected
+    from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 7
+    events with data out of 348 total strong wind events (1976-2013)., Observed hectares
+    of crops/woods destroyed or affected from wildfire (FIRE) events in Colombia.
+    DesInventar records: 10 events with data out of 2,588 total wildfire events (1984-2013).,
+    Observed homes destroyed beyond habitability from coastal flood (SURGE) events
+    in Colombia. DesInventar records: 52 events with data out of 159 total coastal
+    flood events (1984-2013)., Observed homes destroyed beyond habitability from convective
+    storm (HAILSTORM) events in Colombia. DesInventar records: 6 events with data
+    out of 81 total convective storm events (1989-2013)., Observed homes destroyed
+    beyond habitability from earthquake (EARTHQUAKE) events in Colombia. DesInventar
+    records: 359 events with data out of 888 total earthquake events (1986-2013).,
+    Observed homes destroyed beyond habitability from flood (FLOOD) events in Colombia.
+    DesInventar records: 2,279 events with data out of 15,109 total flood events (1984-2013).,
+    Observed homes destroyed beyond habitability from landslide (AVALANCHE) events
+    in Colombia. DesInventar records: 12 events with data out of 25 total landslide
+    events (1995-2009)., Observed homes destroyed beyond habitability from landslide
+    (LANDSLIDE) events in Colombia. DesInventar records: 2,060 events with data out
+    of 9,041 total landslide events (1984-2013)., Observed homes destroyed beyond
+    habitability from strong wind (HURRICANE) events in Colombia. DesInventar records:
+    5 events with data out of 7 total strong wind events (1963-1988)., Observed homes
+    destroyed beyond habitability from strong wind (SNOWSTORM, STORM) events in Colombia.
+    DesInventar records: 94 events with data out of 348 total strong wind events (1976-2013).,
+    Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in
+    Colombia. DesInventar records: 3 events with data out of 5 total tsunami events
+    (1979-1979)., Observed homes destroyed beyond habitability from wildfire (FIRE)
+    events in Colombia. DesInventar records: 922 events with data out of 2,588 total
+    wildfire events (1984-2013)., Observed homes with non-structural damage, still
+    habitable from coastal flood (SURGE) events in Colombia. DesInventar records:
+    33 events with data out of 159 total coastal flood events (1984-2013)., Observed
+    homes with non-structural damage, still habitable from convective storm (HAILSTORM)
+    events in Colombia. DesInventar records: 30 events with data out of 81 total convective
+    storm events (1989-2013)., Observed homes with non-structural damage, still habitable
+    from drought (DROUGHT) events in Colombia. DesInventar records: 2 events with
+    data out of 591 total drought events (1985-2012)., Observed homes with non-structural
+    damage, still habitable from earthquake (EARTHQUAKE) events in Colombia. DesInventar
+    records: 362 events with data out of 888 total earthquake events (1986-2013).,
+    Observed homes with non-structural damage, still habitable from flood (FLOOD)
+    events in Colombia. DesInventar records: 5,361 events with data out of 15,109
+    total flood events (1984-2013)., Observed homes with non-structural damage, still
+    habitable from landslide (AVALANCHE) events in Colombia. DesInventar records:
+    14 events with data out of 25 total landslide events (1995-2009)., Observed homes
+    with non-structural damage, still habitable from landslide (LANDSLIDE) events
+    in Colombia. DesInventar records: 2,153 events with data out of 9,041 total landslide
+    events (1984-2013)., Observed homes with non-structural damage, still habitable
+    from strong wind (HURRICANE) events in Colombia. DesInventar records: 2 events
+    with data out of 7 total strong wind events (1963-1988)., Observed homes with
+    non-structural damage, still habitable from strong wind (SNOWSTORM, STORM) events
+    in Colombia. DesInventar records: 48 events with data out of 348 total strong
+    wind events (1976-2013)., Observed homes with non-structural damage, still habitable
+    from tsunami (TSUNAMI) events in Colombia. DesInventar records: 5 events with
+    data out of 5 total tsunami events (1979-1979)., Observed homes with non-structural
+    damage, still habitable from wildfire (FIRE) events in Colombia. DesInventar records:
+    401 events with data out of 2,588 total wildfire events (1984-2013)., Observed
+    livestock lost from convective storm (HAILSTORM) events in Colombia. DesInventar
+    records: 1 events with data out of 81 total convective storm events (1989-2013).,
+    Observed livestock lost from drought (DROUGHT) events in Colombia. DesInventar
+    records: 6 events with data out of 591 total drought events (1985-2012)., Observed
+    livestock lost from extreme temperature (FROST) events in Colombia. DesInventar
+    records: 1 events with data out of 62 total extreme temperature events (1985-2013).,
+    Observed livestock lost from flood (FLOOD) events in Colombia. DesInventar records:
+    27 events with data out of 15,109 total flood events (1984-2013)., Observed livestock
+    lost from landslide (LANDSLIDE) events in Colombia. DesInventar records: 4 events
+    with data out of 9,041 total landslide events (1984-2013)., Observed livestock
+    lost from wildfire (FIRE) events in Colombia. DesInventar records: 1 events with
+    data out of 2,588 total wildfire events (1984-2013)., Observed metres of transport
+    networks destroyed from coastal flood (SURGE) events in Colombia. DesInventar
+    records: 2 events with data out of 159 total coastal flood events (1984-2013).,
+    Observed metres of transport networks destroyed from convective storm (HAILSTORM)
+    events in Colombia. DesInventar records: 1 events with data out of 81 total convective
+    storm events (1989-2013)., Observed metres of transport networks destroyed from
+    earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 19 events with
+    data out of 888 total earthquake events (1986-2013)., Observed metres of transport
+    networks destroyed from flood (FLOOD) events in Colombia. DesInventar records:
+    484 events with data out of 15,109 total flood events (1984-2013)., Observed metres
+    of transport networks destroyed from landslide (LANDSLIDE) events in Colombia.
+    DesInventar records: 747 events with data out of 9,041 total landslide events
+    (1984-2013)., Observed metres of transport networks destroyed from strong wind
+    (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of
+    7 total strong wind events (1963-1988)., Observed metres of transport networks
+    destroyed from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar
+    records: 5 events with data out of 348 total strong wind events (1976-2013).,
+    Observed metres of transport networks destroyed from wildfire (FIRE) events in
+    Colombia. DesInventar records: 1 events with data out of 2,588 total wildfire
+    events (1984-2013)., Observed persons indirectly affected (disruption to services,
+    commerce, work) from coastal flood (SURGE) events in Colombia. DesInventar records:
+    52 events with data out of 159 total coastal flood events (1984-2013)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from convective
+    storm (HAILSTORM) events in Colombia. DesInventar records: 39 events with data
+    out of 81 total convective storm events (1989-2013)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from drought (DROUGHT) events
+    in Colombia. DesInventar records: 115 events with data out of 591 total drought
+    events (1985-2012)., Observed persons indirectly affected (disruption to services,
+    commerce, work) from earthquake (EARTHQUAKE) events in Colombia. DesInventar records:
+    211 events with data out of 888 total earthquake events (1986-2013)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from extreme
+    temperature (FROST) events in Colombia. DesInventar records: 6 events with data
+    out of 62 total extreme temperature events (1985-2013)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from flood (FLOOD) events in
+    Colombia. DesInventar records: 8,904 events with data out of 15,109 total flood
+    events (1984-2013)., Observed persons indirectly affected (disruption to services,
+    commerce, work) from landslide (AVALANCHE) events in Colombia. DesInventar records:
+    23 events with data out of 25 total landslide events (1995-2009)., Observed persons
+    indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE)
+    events in Colombia. DesInventar records: 3,212 events with data out of 9,041 total
+    landslide events (1984-2013)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from strong wind (HURRICANE) events in Colombia.
+    DesInventar records: 4 events with data out of 7 total strong wind events (1963-1988).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 42
+    events with data out of 348 total strong wind events (1976-2013)., Observed persons
+    indirectly affected (disruption to services, commerce, work) from tsunami (TSUNAMI)
+    events in Colombia. DesInventar records: 1 events with data out of 5 total tsunami
+    events (1979-1979)., Observed persons indirectly affected (disruption to services,
+    commerce, work) from wildfire (FIRE) events in Colombia. DesInventar records:
+    893 events with data out of 2,588 total wildfire events (1984-2013)., Observed
+    persons injured or made sick directly by disaster events from coastal flood (SURGE)
+    events in Colombia. DesInventar records: 4 events with data out of 159 total coastal
+    flood events (1984-2013)., Observed persons injured or made sick directly by disaster
+    events from convective storm (HAILSTORM) events in Colombia. DesInventar records:
+    2 events with data out of 81 total convective storm events (1989-2013)., Observed
+    persons injured or made sick directly by disaster events from earthquake (EARTHQUAKE)
+    events in Colombia. DesInventar records: 158 events with data out of 888 total
+    earthquake events (1986-2013)., Observed persons injured or made sick directly
+    by disaster events from flood (FLOOD) events in Colombia. DesInventar records:
+    237 events with data out of 15,109 total flood events (1984-2013)., Observed persons
+    injured or made sick directly by disaster events from landslide (AVALANCHE) events
+    in Colombia. DesInventar records: 3 events with data out of 25 total landslide
+    events (1995-2009)., Observed persons injured or made sick directly by disaster
+    events from landslide (LANDSLIDE) events in Colombia. DesInventar records: 749
+    events with data out of 9,041 total landslide events (1984-2013)., Observed persons
+    injured or made sick directly by disaster events from strong wind (HURRICANE)
+    events in Colombia. DesInventar records: 1 events with data out of 7 total strong
+    wind events (1963-1988)., Observed persons injured or made sick directly by disaster
+    events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
+    54 events with data out of 348 total strong wind events (1976-2013)., Observed
+    persons injured or made sick directly by disaster events from tsunami (TSUNAMI)
+    events in Colombia. DesInventar records: 5 events with data out of 5 total tsunami
+    events (1979-1979)., Observed persons injured or made sick directly by disaster
+    events from wildfire (FIRE) events in Colombia. DesInventar records: 417 events
+    with data out of 2,588 total wildfire events (1984-2013)., Observed persons missing
+    or unaccounted for after disaster events from coastal flood (SURGE) events in
+    Colombia. DesInventar records: 9 events with data out of 159 total coastal flood
+    events (1984-2013)., Observed persons missing or unaccounted for after disaster
+    events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 22
+    events with data out of 888 total earthquake events (1986-2013)., Observed persons
+    missing or unaccounted for after disaster events from flood (FLOOD) events in
+    Colombia. DesInventar records: 199 events with data out of 15,109 total flood
+    events (1984-2013)., Observed persons missing or unaccounted for after disaster
+    events from landslide (AVALANCHE) events in Colombia. DesInventar records: 2 events
+    with data out of 25 total landslide events (1995-2009)., Observed persons missing
+    or unaccounted for after disaster events from landslide (LANDSLIDE) events in
+    Colombia. DesInventar records: 140 events with data out of 9,041 total landslide
+    events (1984-2013)., Observed persons missing or unaccounted for after disaster
+    events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
+    4 events with data out of 348 total strong wind events (1976-2013)., Observed
+    persons missing or unaccounted for after disaster events from tsunami (TSUNAMI)
+    events in Colombia. DesInventar records: 3 events with data out of 5 total tsunami
+    events (1979-1979)., Observed persons missing or unaccounted for after disaster
+    events from wildfire (FIRE) events in Colombia. DesInventar records: 4 events
+    with data out of 2,588 total wildfire events (1984-2013)., Observed persons permanently
+    relocated from homes from flood (FLOOD) events in Colombia. DesInventar records:
+    23 events with data out of 15,109 total flood events (1984-2013)., Observed persons
+    permanently relocated from homes from landslide (LANDSLIDE) events in Colombia.
+    DesInventar records: 7 events with data out of 9,041 total landslide events (1984-2013).,
+    Observed persons temporarily evacuated from homes or workplaces from coastal flood
+    (SURGE) events in Colombia. DesInventar records: 8 events with data out of 159
+    total coastal flood events (1984-2013)., Observed persons temporarily evacuated
+    from homes or workplaces from earthquake (EARTHQUAKE) events in Colombia. DesInventar
+    records: 11 events with data out of 888 total earthquake events (1986-2013).,
+    Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD)
+    events in Colombia. DesInventar records: 423 events with data out of 15,109 total
+    flood events (1984-2013)., Observed persons temporarily evacuated from homes or
+    workplaces from landslide (LANDSLIDE) events in Colombia. DesInventar records:
+    142 events with data out of 9,041 total landslide events (1984-2013)., Observed
+    persons temporarily evacuated from homes or workplaces from strong wind (HURRICANE)
+    events in Colombia. DesInventar records: 1 events with data out of 7 total strong
+    wind events (1963-1988)., Observed persons temporarily evacuated from homes or
+    workplaces from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar
+    records: 4 events with data out of 348 total strong wind events (1976-2013).,
+    Observed persons temporarily evacuated from homes or workplaces from wildfire
+    (FIRE) events in Colombia. DesInventar records: 18 events with data out of 2,588
+    total wildfire events (1984-2013)., Observed persons whose goods/services suffered
+    serious damage from coastal flood (SURGE) events in Colombia. DesInventar records:
+    12 events with data out of 159 total coastal flood events (1984-2013)., Observed
+    persons whose goods/services suffered serious damage from convective storm (HAILSTORM)
+    events in Colombia. DesInventar records: 4 events with data out of 81 total convective
+    storm events (1989-2013)., Observed persons whose goods/services suffered serious
+    damage from drought (DROUGHT) events in Colombia. DesInventar records: 1 events
+    with data out of 591 total drought events (1985-2012)., Observed persons whose
+    goods/services suffered serious damage from earthquake (EARTHQUAKE) events in
+    Colombia. DesInventar records: 195 events with data out of 888 total earthquake
+    events (1986-2013)., Observed persons whose goods/services suffered serious damage
+    from extreme temperature (FROST) events in Colombia. DesInventar records: 2 events
+    with data out of 62 total extreme temperature events (1985-2013)., Observed persons
+    whose goods/services suffered serious damage from flood (FLOOD) events in Colombia.
+    DesInventar records: 1,131 events with data out of 15,109 total flood events (1984-2013).,
+    Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE)
+    events in Colombia. DesInventar records: 471 events with data out of 9,041 total
+    landslide events (1984-2013)., Observed persons whose goods/services suffered
+    serious damage from strong wind (HURRICANE) events in Colombia. DesInventar records:
+    1 events with data out of 7 total strong wind events (1963-1988)., Observed persons
+    whose goods/services suffered serious damage from strong wind (SNOWSTORM, STORM)
+    events in Colombia. DesInventar records: 41 events with data out of 348 total
+    strong wind events (1976-2013)., Observed persons whose goods/services suffered
+    serious damage from wildfire (FIRE) events in Colombia. DesInventar records: 476
+    events with data out of 2,588 total wildfire events (1984-2013)., Observed total
+    economic losses in US Dollars from earthquake (EARTHQUAKE) events in Colombia.
+    DesInventar records: 2 events with data out of 888 total earthquake events (1986-2013).,
+    Observed total economic losses in US Dollars from flood (FLOOD) events in Colombia.
+    DesInventar records: 1 events with data out of 15,109 total flood events (1984-2013).,
+    Observed total economic losses in US Dollars from landslide (LANDSLIDE) events
+    in Colombia. DesInventar records: 4 events with data out of 9,041 total landslide
+    events (1984-2013)., Observed total economic losses in US Dollars from landslide
+    (SEDIMENTATION) events in Colombia. DesInventar records: 1 events with data out
+    of 12 total landslide events (1984-1985)., Observed total economic losses in US
+    Dollars from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
+    1 events with data out of 348 total strong wind events (1976-2013)., Observed
+    total economic losses in local currency from coastal flood (SURGE) events in Colombia.
+    DesInventar records: 8 events with data out of 159 total coastal flood events
+    (1984-2013)., Observed total economic losses in local currency from convective
+    storm (HAILSTORM) events in Colombia. DesInventar records: 11 events with data
+    out of 81 total convective storm events (1989-2013)., Observed total economic
+    losses in local currency from drought (DROUGHT) events in Colombia. DesInventar
+    records: 25 events with data out of 591 total drought events (1985-2012)., Observed
+    total economic losses in local currency from earthquake (EARTHQUAKE) events in
+    Colombia. DesInventar records: 23 events with data out of 888 total earthquake
+    events (1986-2013)., Observed total economic losses in local currency from extreme
+    temperature (FROST) events in Colombia. DesInventar records: 7 events with data
+    out of 62 total extreme temperature events (1985-2013)., Observed total economic
+    losses in local currency from flood (FLOOD) events in Colombia. DesInventar records:
+    958 events with data out of 15,109 total flood events (1984-2013)., Observed total
+    economic losses in local currency from landslide (LANDSLIDE) events in Colombia.
+    DesInventar records: 205 events with data out of 9,041 total landslide events
+    (1984-2013)., Observed total economic losses in local currency from strong wind
+    (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of
+    7 total strong wind events (1963-1988)., Observed total economic losses in local
+    currency from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
+    38 events with data out of 348 total strong wind events (1976-2013)., Observed
+    total economic losses in local currency from wildfire (FIRE) events in Colombia.
+    DesInventar records: 901 events with data out of 2,588 total wildfire events (1984-2013).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, extreme_cold, fluvial_flood, ground_motion,
+    landslide_general, landslide_mudflow, meteorological_drought, snow_avalanche,
+    storm_surge, tornado, tropical_cyclone, tsunami, wildfire
+  hazard_type: coastal_flood, convective_storm, drought, earthquake, extreme_temperature,
+    flood, landslide, strong_wind, tsunami, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Colombia from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Colombia
+  download_url: https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79/resource/93b7528b-46fd-4504-9406-f4d97a59a24c/download/colombia.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Colombia
+- coordinate_system: null
+  description: Disaster Tabular data for Colombia
+  download_url: https://data.humdata.org/dataset/baeedcfd-14c7-4028-8eb0-e1192e82dc79/resource/f156b3b5-97ab-48a5-b66d-5c00d56f85c9/download/di_report-colombia.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster Tabular data for Colombia
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-colundrr_desinventar
+spatial:
+  bbox:
+  - -81.72
+  - -4.24
+  - -66.88
+  - 13.58
+  countries:
+  - COL
+  gazetteer_entries:
+  - description: Colombia
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/3686110/colombia.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Colombia
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-criundrr_desinventar.md
+++ b/_datasets/rdls_lss-criundrr_desinventar.md
@@ -1,0 +1,285 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Comision Nacional de Prevencion de Riesgos y Atencion de Emergencias (CNE)
+  url: https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-criundrr_desinventar
+description: 'National disaster loss inventory for Costa Rica from the DesInventar
+  Sendai Framework Monitor database, compiled by Comision Nacional de Prevencion de
+  Riesgos y Atencion de Emergencias (CNE) and published by the United Nations Office
+  for Disaster Risk Reduction (UNDRR). Contains 13,693 event-level loss records covering
+  1970-2016, with observed impacts from coastal_flood, convective_storm, drought,
+  earthquake, flood, landslide, strong_wind, wildfire events. Loss data includes human
+  casualties, displacement, building damage, economic losses, agricultural damage,
+  and infrastructure impacts. [Source: This metadata record was automatically extracted
+  from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original
+  dataset: https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3]'
+details: 'Event-level disaster loss records from the DesInventar database for Costa
+  Rica, maintained by Comision Nacional de Prevencion de Riesgos y Atencion de Emergencias
+  (CNE). Covers 13,693 observed disaster events from 1970-2016. Data collected through
+  direct observational reporting and includes human impacts (deaths, injuries, missing,
+  affected, evacuated, relocated), physical impacts (houses destroyed/damaged, education
+  centres, hospitals, roads), economic losses (local currency and USD), and agricultural
+  impacts (crop damage in hectares, livestock losses). Methodology: Direct Observational
+  Data / Anecdotal Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from coastal flood
+    (SURGE) events in Costa Rica. DesInventar records: 5 events with data out of 59
+    total coastal flood events (1970-2015)., Observed deaths directly caused by disaster
+    events from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records:
+    15 events with data out of 348 total earthquake events (1973-2012)., Observed
+    deaths directly caused by disaster events from flood (FLOOD) events in Costa Rica.
+    DesInventar records: 68 events with data out of 8,334 total flood events (1970-2016).,
+    Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+    events in Costa Rica. DesInventar records: 85 events with data out of 3,596 total
+    landslide events (1970-2016)., Observed deaths directly caused by disaster events
+    from strong wind (STORM) events in Costa Rica. DesInventar records: 3 events with
+    data out of 14 total strong wind events (1995-2014)., Observed deaths directly
+    caused by disaster events from wildfire (FIRE) events in Costa Rica. DesInventar
+    records: 56 events with data out of 902 total wildfire events (1980-2013)., Observed
+    educational facilities destroyed or affected from earthquake (EARTHQUAKE) events
+    in Costa Rica. DesInventar records: 77 events with data out of 348 total earthquake
+    events (1973-2012)., Observed educational facilities destroyed or affected from
+    flood (FLOOD) events in Costa Rica. DesInventar records: 170 events with data
+    out of 8,334 total flood events (1970-2016)., Observed educational facilities
+    destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar
+    records: 33 events with data out of 3,596 total landslide events (1970-2016).,
+    Observed educational facilities destroyed or affected from wildfire (FIRE) events
+    in Costa Rica. DesInventar records: 12 events with data out of 902 total wildfire
+    events (1980-2013)., Observed health facilities destroyed or affected from earthquake
+    (EARTHQUAKE) events in Costa Rica. DesInventar records: 22 events with data out
+    of 348 total earthquake events (1973-2012)., Observed health facilities destroyed
+    or affected from flood (FLOOD) events in Costa Rica. DesInventar records: 25 events
+    with data out of 8,334 total flood events (1970-2016)., Observed health facilities
+    destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar
+    records: 3 events with data out of 3,596 total landslide events (1970-2016).,
+    Observed health facilities destroyed or affected from wildfire (FIRE) events in
+    Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire
+    events (1980-2013)., Observed hectares of crops/woods destroyed or affected from
+    drought (DROUGHT) events in Costa Rica. DesInventar records: 29 events with data
+    out of 438 total drought events (1972-2014)., Observed hectares of crops/woods
+    destroyed or affected from flood (FLOOD) events in Costa Rica. DesInventar records:
+    10 events with data out of 8,334 total flood events (1970-2016)., Observed hectares
+    of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Costa
+    Rica. DesInventar records: 4 events with data out of 3,596 total landslide events
+    (1970-2016)., Observed homes destroyed beyond habitability from coastal flood
+    (SURGE) events in Costa Rica. DesInventar records: 6 events with data out of 59
+    total coastal flood events (1970-2015)., Observed homes destroyed beyond habitability
+    from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 132 events
+    with data out of 348 total earthquake events (1973-2012)., Observed homes destroyed
+    beyond habitability from flood (FLOOD) events in Costa Rica. DesInventar records:
+    220 events with data out of 8,334 total flood events (1970-2016)., Observed homes
+    destroyed beyond habitability from landslide (LANDSLIDE) events in Costa Rica.
+    DesInventar records: 154 events with data out of 3,596 total landslide events
+    (1970-2016)., Observed homes destroyed beyond habitability from strong wind (STORM)
+    events in Costa Rica. DesInventar records: 2 events with data out of 14 total
+    strong wind events (1995-2014)., Observed homes destroyed beyond habitability
+    from wildfire (FIRE) events in Costa Rica. DesInventar records: 463 events with
+    data out of 902 total wildfire events (1980-2013)., Observed homes with non-structural
+    damage, still habitable from coastal flood (SURGE) events in Costa Rica. DesInventar
+    records: 22 events with data out of 59 total coastal flood events (1970-2015).,
+    Observed homes with non-structural damage, still habitable from convective storm
+    (HAILSTORM) events in Costa Rica. DesInventar records: 2 events with data out
+    of 2 total convective storm events (1993-2012)., Observed homes with non-structural
+    damage, still habitable from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar
+    records: 148 events with data out of 348 total earthquake events (1973-2012).,
+    Observed homes with non-structural damage, still habitable from flood (FLOOD)
+    events in Costa Rica. DesInventar records: 3,716 events with data out of 8,334
+    total flood events (1970-2016)., Observed homes with non-structural damage, still
+    habitable from landslide (LANDSLIDE) events in Costa Rica. DesInventar records:
+    1,402 events with data out of 3,596 total landslide events (1970-2016)., Observed
+    homes with non-structural damage, still habitable from strong wind (STORM) events
+    in Costa Rica. DesInventar records: 12 events with data out of 14 total strong
+    wind events (1995-2014)., Observed homes with non-structural damage, still habitable
+    from wildfire (FIRE) events in Costa Rica. DesInventar records: 202 events with
+    data out of 902 total wildfire events (1980-2013)., Observed livestock lost from
+    drought (DROUGHT) events in Costa Rica. DesInventar records: 1 events with data
+    out of 438 total drought events (1972-2014)., Observed livestock lost from earthquake
+    (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events with data out
+    of 348 total earthquake events (1973-2012)., Observed livestock lost from landslide
+    (LANDSLIDE) events in Costa Rica. DesInventar records: 2 events with data out
+    of 3,596 total landslide events (1970-2016)., Observed metres of transport networks
+    destroyed from coastal flood (SURGE) events in Costa Rica. DesInventar records:
+    2 events with data out of 59 total coastal flood events (1970-2015)., Observed
+    metres of transport networks destroyed from flood (FLOOD) events in Costa Rica.
+    DesInventar records: 49 events with data out of 8,334 total flood events (1970-2016).,
+    Observed metres of transport networks destroyed from landslide (LANDSLIDE) events
+    in Costa Rica. DesInventar records: 212 events with data out of 3,596 total landslide
+    events (1970-2016)., Observed persons indirectly affected (disruption to services,
+    commerce, work) from coastal flood (SURGE) events in Costa Rica. DesInventar records:
+    1 events with data out of 59 total coastal flood events (1970-2015)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from flood
+    (FLOOD) events in Costa Rica. DesInventar records: 105 events with data out of
+    8,334 total flood events (1970-2016)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from landslide (LANDSLIDE) events in Costa Rica.
+    DesInventar records: 44 events with data out of 3,596 total landslide events (1970-2016).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from wildfire (FIRE) events in Costa Rica. DesInventar records: 10 events with
+    data out of 902 total wildfire events (1980-2013)., Observed persons injured or
+    made sick directly by disaster events from coastal flood (SURGE) events in Costa
+    Rica. DesInventar records: 2 events with data out of 59 total coastal flood events
+    (1970-2015)., Observed persons injured or made sick directly by disaster events
+    from flood (FLOOD) events in Costa Rica. DesInventar records: 10 events with data
+    out of 8,334 total flood events (1970-2016)., Observed persons injured or made
+    sick directly by disaster events from landslide (LANDSLIDE) events in Costa Rica.
+    DesInventar records: 14 events with data out of 3,596 total landslide events (1970-2016).,
+    Observed persons injured or made sick directly by disaster events from wildfire
+    (FIRE) events in Costa Rica. DesInventar records: 1 events with data out of 902
+    total wildfire events (1980-2013)., Observed persons missing or unaccounted for
+    after disaster events from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar
+    records: 1 events with data out of 348 total earthquake events (1973-2012)., Observed
+    persons missing or unaccounted for after disaster events from flood (FLOOD) events
+    in Costa Rica. DesInventar records: 13 events with data out of 8,334 total flood
+    events (1970-2016)., Observed persons missing or unaccounted for after disaster
+    events from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 7
+    events with data out of 3,596 total landslide events (1970-2016)., Observed persons
+    permanently relocated from homes from earthquake (EARTHQUAKE) events in Costa
+    Rica. DesInventar records: 2 events with data out of 348 total earthquake events
+    (1973-2012)., Observed persons permanently relocated from homes from flood (FLOOD)
+    events in Costa Rica. DesInventar records: 19 events with data out of 8,334 total
+    flood events (1970-2016)., Observed persons permanently relocated from homes from
+    landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 7 events with
+    data out of 3,596 total landslide events (1970-2016)., Observed persons permanently
+    relocated from homes from wildfire (FIRE) events in Costa Rica. DesInventar records:
+    1 events with data out of 902 total wildfire events (1980-2013)., Observed persons
+    temporarily evacuated from homes or workplaces from coastal flood (SURGE) events
+    in Costa Rica. DesInventar records: 3 events with data out of 59 total coastal
+    flood events (1970-2015)., Observed persons temporarily evacuated from homes or
+    workplaces from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records:
+    10 events with data out of 348 total earthquake events (1973-2012)., Observed
+    persons temporarily evacuated from homes or workplaces from flood (FLOOD) events
+    in Costa Rica. DesInventar records: 795 events with data out of 8,334 total flood
+    events (1970-2016)., Observed persons temporarily evacuated from homes or workplaces
+    from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 106 events
+    with data out of 3,596 total landslide events (1970-2016)., Observed persons whose
+    goods/services suffered serious damage from coastal flood (SURGE) events in Costa
+    Rica. DesInventar records: 17 events with data out of 59 total coastal flood events
+    (1970-2015)., Observed persons whose goods/services suffered serious damage from
+    convective storm (HAILSTORM) events in Costa Rica. DesInventar records: 1 events
+    with data out of 2 total convective storm events (1993-2012)., Observed persons
+    whose goods/services suffered serious damage from drought (DROUGHT) events in
+    Costa Rica. DesInventar records: 22 events with data out of 438 total drought
+    events (1972-2014)., Observed persons whose goods/services suffered serious damage
+    from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 150 events
+    with data out of 348 total earthquake events (1973-2012)., Observed persons whose
+    goods/services suffered serious damage from flood (FLOOD) events in Costa Rica.
+    DesInventar records: 2,394 events with data out of 8,334 total flood events (1970-2016).,
+    Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE)
+    events in Costa Rica. DesInventar records: 680 events with data out of 3,596 total
+    landslide events (1970-2016)., Observed persons whose goods/services suffered
+    serious damage from strong wind (STORM) events in Costa Rica. DesInventar records:
+    10 events with data out of 14 total strong wind events (1995-2014)., Observed
+    persons whose goods/services suffered serious damage from wildfire (FIRE) events
+    in Costa Rica. DesInventar records: 172 events with data out of 902 total wildfire
+    events (1980-2013)., Observed total economic losses in US Dollars from drought
+    (DROUGHT) events in Costa Rica. DesInventar records: 18 events with data out of
+    438 total drought events (1972-2014)., Observed total economic losses in US Dollars
+    from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events
+    with data out of 348 total earthquake events (1973-2012)., Observed total economic
+    losses in US Dollars from flood (FLOOD) events in Costa Rica. DesInventar records:
+    4 events with data out of 8,334 total flood events (1970-2016)., Observed total
+    economic losses in US Dollars from landslide (LANDSLIDE) events in Costa Rica.
+    DesInventar records: 8 events with data out of 3,596 total landslide events (1970-2016).,
+    Observed total economic losses in US Dollars from wildfire (FIRE) events in Costa
+    Rica. DesInventar records: 229 events with data out of 902 total wildfire events
+    (1980-2013)., Observed total economic losses in local currency from coastal flood
+    (SURGE) events in Costa Rica. DesInventar records: 1 events with data out of 59
+    total coastal flood events (1970-2015)., Observed total economic losses in local
+    currency from drought (DROUGHT) events in Costa Rica. DesInventar records: 25
+    events with data out of 438 total drought events (1972-2014)., Observed total
+    economic losses in local currency from earthquake (EARTHQUAKE) events in Costa
+    Rica. DesInventar records: 6 events with data out of 348 total earthquake events
+    (1973-2012)., Observed total economic losses in local currency from flood (FLOOD)
+    events in Costa Rica. DesInventar records: 25 events with data out of 8,334 total
+    flood events (1970-2016)., Observed total economic losses in local currency from
+    landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 24 events with
+    data out of 3,596 total landslide events (1970-2016)., Observed total economic
+    losses in local currency from wildfire (FIRE) events in Costa Rica. DesInventar
+    records: 242 events with data out of 902 total wildfire events (1980-2013).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, ground_motion, landslide_general,
+    meteorological_drought, storm_surge, tornado, wildfire
+  hazard_type: coastal_flood, convective_storm, drought, earthquake, flood, landslide,
+    strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Costa Rica from the DesInventar
+  national disaster loss inventory, supporting disaster risk reduction monitoring
+  under the Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Costa Rica
+  download_url: https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3/resource/293b09b9-84bb-44e2-a674-6a2d6d219100/download/costarica.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Costa Rica
+- coordinate_system: null
+  description: Disaster tabular data for Costa Rica
+  download_url: https://data.humdata.org/dataset/84aa5ccd-46eb-4bde-b39a-f9cb1a159fc3/resource/d574ac1d-d41e-436a-b108-905d6de744e0/download/di_report-costarica.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster tabular data for Costa Rica
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-criundrr_desinventar
+spatial:
+  bbox:
+  - -87.12
+  - 5.52
+  - -82.56
+  - 11.21
+  countries:
+  - CRI
+  gazetteer_entries:
+  - description: Costa Rica
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/3624060/costa-rica.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Costa Rica
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-ethundrr_desinventar.md
+++ b/_datasets/rdls_lss-ethundrr_desinventar.md
@@ -1,0 +1,223 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Disaster Risk Management and Food Security Sector
+  url: https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-ethundrr_desinventar
+description: 'National disaster loss inventory for Ethiopia from the DesInventar Sendai
+  Framework Monitor database, compiled by Disaster Risk Management and Food Security
+  Sector and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 9,109 event-level loss records covering 1992-2013, with observed impacts
+  from convective_storm, drought, earthquake, extreme_temperature, flood, landslide,
+  strong_wind, wildfire events. Loss data includes human casualties, displacement,
+  building damage, economic losses, agricultural damage, and infrastructure impacts.
+  [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc]'
+details: 'Event-level disaster loss records from the DesInventar database for Ethiopia,
+  maintained by Disaster Risk Management and Food Security Sector. Covers 9,109 observed
+  disaster events from 1992-2013. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from convective
+    storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 17 events
+    with data out of 242 total convective storm events (1996-2012)., Observed deaths
+    directly caused by disaster events from drought (DROUGHT) events in Ethiopia.
+    DesInventar records: 2 events with data out of 5,802 total drought events (1992-2013).,
+    Observed deaths directly caused by disaster events from flood (FLOOD) events in
+    Ethiopia. DesInventar records: 179 events with data out of 1,475 total flood events
+    (2006-2013)., Observed deaths directly caused by disaster events from landslide
+    (LANDSLIDE) events in Ethiopia. DesInventar records: 30 events with data out of
+    141 total landslide events (2001-2013)., Observed deaths directly caused by disaster
+    events from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar
+    records: 2 events with data out of 27 total strong wind events (1996-2009)., Observed
+    deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events
+    in Ethiopia. DesInventar records: 76 events with data out of 1,410 total wildfire
+    events (2000-2013)., Observed educational facilities destroyed or affected from
+    flood (FLOOD) events in Ethiopia. DesInventar records: 4 events with data out
+    of 1,475 total flood events (2006-2013)., Observed health facilities destroyed
+    or affected from flood (FLOOD) events in Ethiopia. DesInventar records: 1 events
+    with data out of 1,475 total flood events (2006-2013)., Observed hectares of crops/woods
+    destroyed or affected from convective storm (HAILSTORM, THUNDERSTORM) events in
+    Ethiopia. DesInventar records: 141 events with data out of 242 total convective
+    storm events (1996-2012)., Observed hectares of crops/woods destroyed or affected
+    from drought (DROUGHT) events in Ethiopia. DesInventar records: 75 events with
+    data out of 5,802 total drought events (1992-2013)., Observed hectares of crops/woods
+    destroyed or affected from extreme temperature (FROST) events in Ethiopia. DesInventar
+    records: 6 events with data out of 7 total extreme temperature events (1999-2005).,
+    Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+    in Ethiopia. DesInventar records: 392 events with data out of 1,475 total flood
+    events (2006-2013)., Observed hectares of crops/woods destroyed or affected from
+    landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 55 events with
+    data out of 141 total landslide events (2001-2013)., Observed hectares of crops/woods
+    destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in
+    Ethiopia. DesInventar records: 5 events with data out of 27 total strong wind
+    events (1996-2009)., Observed hectares of crops/woods destroyed or affected from
+    wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 60 events
+    with data out of 1,410 total wildfire events (2000-2013)., Observed homes destroyed
+    beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in
+    Ethiopia. DesInventar records: 27 events with data out of 242 total convective
+    storm events (1996-2012)., Observed homes destroyed beyond habitability from earthquake
+    (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of
+    3 total earthquake events (1993-2005)., Observed homes destroyed beyond habitability
+    from flood (FLOOD) events in Ethiopia. DesInventar records: 141 events with data
+    out of 1,475 total flood events (2006-2013)., Observed homes destroyed beyond
+    habitability from landslide (LANDSLIDE) events in Ethiopia. DesInventar records:
+    26 events with data out of 141 total landslide events (2001-2013)., Observed homes
+    destroyed beyond habitability from strong wind (SNOWSTORM, STORM, WINDSTORM) events
+    in Ethiopia. DesInventar records: 5 events with data out of 27 total strong wind
+    events (1996-2009)., Observed homes destroyed beyond habitability from wildfire
+    (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 89 events with data
+    out of 1,410 total wildfire events (2000-2013)., Observed homes with non-structural
+    damage, still habitable from convective storm (HAILSTORM, THUNDERSTORM) events
+    in Ethiopia. DesInventar records: 1 events with data out of 242 total convective
+    storm events (1996-2012)., Observed homes with non-structural damage, still habitable
+    from flood (FLOOD) events in Ethiopia. DesInventar records: 31 events with data
+    out of 1,475 total flood events (2006-2013)., Observed homes with non-structural
+    damage, still habitable from landslide (LANDSLIDE) events in Ethiopia. DesInventar
+    records: 2 events with data out of 141 total landslide events (2001-2013)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from convective
+    storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 30 events
+    with data out of 242 total convective storm events (1996-2012)., Observed persons
+    indirectly affected (disruption to services, commerce, work) from drought (DROUGHT)
+    events in Ethiopia. DesInventar records: 5,569 events with data out of 5,802 total
+    drought events (1992-2013)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from earthquake (EARTHQUAKE) events in Ethiopia.
+    DesInventar records: 1 events with data out of 3 total earthquake events (1993-2005).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from extreme temperature (FROST) events in Ethiopia. DesInventar records: 2 events
+    with data out of 7 total extreme temperature events (1999-2005)., Observed persons
+    indirectly affected (disruption to services, commerce, work) from extreme temperature
+    (HEAT WAVE) events in Ethiopia. DesInventar records: 1 events with data out of
+    2 total extreme temperature events (1996-1996)., Observed persons indirectly affected
+    (disruption to services, commerce, work) from flood (FLOOD) events in Ethiopia.
+    DesInventar records: 926 events with data out of 1,475 total flood events (2006-2013).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 54 events
+    with data out of 141 total landslide events (2001-2013)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from strong wind (SNOWSTORM,
+    STORM, WINDSTORM) events in Ethiopia. DesInventar records: 12 events with data
+    out of 27 total strong wind events (1996-2009)., Observed persons indirectly affected
+    (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events
+    in Ethiopia. DesInventar records: 239 events with data out of 1,410 total wildfire
+    events (2000-2013)., Observed persons injured or made sick directly by disaster
+    events from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar
+    records: 5 events with data out of 242 total convective storm events (1996-2012).,
+    Observed persons injured or made sick directly by disaster events from earthquake
+    (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of
+    3 total earthquake events (1993-2005)., Observed persons injured or made sick
+    directly by disaster events from flood (FLOOD) events in Ethiopia. DesInventar
+    records: 27 events with data out of 1,475 total flood events (2006-2013)., Observed
+    persons injured or made sick directly by disaster events from landslide (LANDSLIDE)
+    events in Ethiopia. DesInventar records: 9 events with data out of 141 total landslide
+    events (2001-2013)., Observed persons injured or made sick directly by disaster
+    events from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records:
+    59 events with data out of 1,410 total wildfire events (2000-2013)., Observed
+    persons permanently relocated from homes from convective storm (HAILSTORM, THUNDERSTORM)
+    events in Ethiopia. DesInventar records: 13 events with data out of 242 total
+    convective storm events (1996-2012)., Observed persons permanently relocated from
+    homes from drought (DROUGHT) events in Ethiopia. DesInventar records: 7 events
+    with data out of 5,802 total drought events (1992-2013)., Observed persons permanently
+    relocated from homes from flood (FLOOD) events in Ethiopia. DesInventar records:
+    274 events with data out of 1,475 total flood events (2006-2013)., Observed persons
+    permanently relocated from homes from landslide (LANDSLIDE) events in Ethiopia.
+    DesInventar records: 33 events with data out of 141 total landslide events (2001-2013).,
+    Observed persons permanently relocated from homes from wildfire (FIRE, FOREST
+    FIRE) events in Ethiopia. DesInventar records: 34 events with data out of 1,410
+    total wildfire events (2000-2013)., Observed total economic losses in local currency
+    from flood (FLOOD) events in Ethiopia. DesInventar records: 3 events with data
+    out of 1,475 total flood events (2006-2013)., Observed total economic losses in
+    local currency from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar
+    records: 570 events with data out of 1,410 total wildfire events (2000-2013).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, extreme_cold, extreme_heat, fluvial_flood,
+    ground_motion, landslide_general, meteorological_drought, tornado, wildfire
+  hazard_type: convective_storm, drought, earthquake, extreme_temperature, flood,
+    landslide, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Ethiopia from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: DesInventar disaster loss data for Ethiopia
+  download_url: https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc/resource/b4577974-a689-40e0-a64d-6ea232aea57b/download/eth.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: ETH.zip
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims   Affected, Relocated, Evacuated, Losses and Damages in crops Ha.
+  download_url: https://data.humdata.org/dataset/3497f102-c9b0-4959-bc74-d98985e302fc/resource/e5bc14ca-9408-4e9d-ba04-99a273259fc6/download/ethiopa.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims   Affected,
+    Relocated, Evacuated, Losses and Damages in crops Ha.
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-ethundrr_desinventar
+spatial:
+  bbox:
+  - 32.99
+  - 3.4
+  - 47.98
+  - 14.88
+  countries:
+  - ETH
+  gazetteer_entries:
+  - description: Ethiopia
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/337996/ethiopia.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Ethiopia
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-idnundrr_desinventar.md
+++ b/_datasets/rdls_lss-idnundrr_desinventar.md
@@ -1,0 +1,225 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Badan Nasional Penanggulangan Bencana (BNPB)
+  url: https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-idnundrr_desinventar
+description: 'National disaster loss inventory for Indonesia from the DesInventar
+  Sendai Framework Monitor database, compiled by Badan Nasional Penanggulangan Bencana
+  (BNPB) and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 5,307 event-level loss records covering 1973-2012, with observed impacts
+  from coastal_flood, drought, earthquake, tsunami, wildfire events. Loss data includes
+  human casualties, displacement, building damage, economic losses, agricultural damage,
+  and infrastructure impacts. [Source: This metadata record was automatically extracted
+  from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original
+  dataset: https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366]'
+details: 'Event-level disaster loss records from the DesInventar database for Indonesia,
+  maintained by Badan Nasional Penanggulangan Bencana (BNPB). Covers 5,307 observed
+  disaster events from 1973-2012. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from coastal flood
+    (SURGE) events in Indonesia. DesInventar records: 17 events with data out of 270
+    total coastal flood events (2009-2011)., Observed deaths directly caused by disaster
+    events from drought (DROUGHT) events in Indonesia. DesInventar records: 1 events
+    with data out of 1,748 total drought events (2004-2008)., Observed deaths directly
+    caused by disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
+    records: 165 events with data out of 449 total earthquake events (1976-2004).,
+    Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events
+    in Indonesia. DesInventar records: 11 events with data out of 13 total tsunami
+    events (1973-1977)., Observed deaths directly caused by disaster events from wildfire
+    (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 145 events with
+    data out of 2,827 total wildfire events (2005-2012)., Observed educational facilities
+    destroyed or affected from coastal flood (SURGE) events in Indonesia. DesInventar
+    records: 11 events with data out of 270 total coastal flood events (2009-2011).,
+    Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE)
+    events in Indonesia. DesInventar records: 171 events with data out of 449 total
+    earthquake events (1976-2004)., Observed educational facilities destroyed or affected
+    from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 2 events with
+    data out of 13 total tsunami events (1973-1977)., Observed educational facilities
+    destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar
+    records: 50 events with data out of 2,827 total wildfire events (2005-2012).,
+    Observed health facilities destroyed or affected from coastal flood (SURGE) events
+    in Indonesia. DesInventar records: 6 events with data out of 270 total coastal
+    flood events (2009-2011)., Observed health facilities destroyed or affected from
+    earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 83 events with
+    data out of 449 total earthquake events (1976-2004)., Observed health facilities
+    destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar
+    records: 1 events with data out of 13 total tsunami events (1973-1977)., Observed
+    health facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events
+    in Indonesia. DesInventar records: 14 events with data out of 2,827 total wildfire
+    events (2005-2012)., Observed hectares of crops/woods destroyed or affected from
+    coastal flood (SURGE) events in Indonesia. DesInventar records: 5 events with
+    data out of 270 total coastal flood events (2009-2011)., Observed hectares of
+    crops/woods destroyed or affected from drought (DROUGHT) events in Indonesia.
+    DesInventar records: 1,352 events with data out of 1,748 total drought events
+    (2004-2008)., Observed hectares of crops/woods destroyed or affected from earthquake
+    (EARTHQUAKE) events in Indonesia. DesInventar records: 5 events with data out
+    of 449 total earthquake events (1976-2004)., Observed hectares of crops/woods
+    destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar
+    records: 2 events with data out of 13 total tsunami events (1973-1977)., Observed
+    hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE)
+    events in Indonesia. DesInventar records: 12 events with data out of 2,827 total
+    wildfire events (2005-2012)., Observed homes destroyed beyond habitability from
+    coastal flood (SURGE) events in Indonesia. DesInventar records: 93 events with
+    data out of 270 total coastal flood events (2009-2011)., Observed homes destroyed
+    beyond habitability from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
+    records: 188 events with data out of 449 total earthquake events (1976-2004).,
+    Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in
+    Indonesia. DesInventar records: 6 events with data out of 13 total tsunami events
+    (1973-1977)., Observed homes destroyed beyond habitability from wildfire (FIRE,
+    FOREST FIRE) events in Indonesia. DesInventar records: 1,088 events with data
+    out of 2,827 total wildfire events (2005-2012)., Observed homes with non-structural
+    damage, still habitable from coastal flood (SURGE) events in Indonesia. DesInventar
+    records: 55 events with data out of 270 total coastal flood events (2009-2011).,
+    Observed homes with non-structural damage, still habitable from earthquake (EARTHQUAKE)
+    events in Indonesia. DesInventar records: 171 events with data out of 449 total
+    earthquake events (1976-2004)., Observed homes with non-structural damage, still
+    habitable from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 1 events
+    with data out of 13 total tsunami events (1973-1977)., Observed homes with non-structural
+    damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Indonesia.
+    DesInventar records: 92 events with data out of 2,827 total wildfire events (2005-2012).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from coastal flood (SURGE) events in Indonesia. DesInventar records: 32 events
+    with data out of 270 total coastal flood events (2009-2011)., Observed persons
+    indirectly affected (disruption to services, commerce, work) from drought (DROUGHT)
+    events in Indonesia. DesInventar records: 38 events with data out of 1,748 total
+    drought events (2004-2008)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from earthquake (EARTHQUAKE) events in Indonesia.
+    DesInventar records: 29 events with data out of 449 total earthquake events (1976-2004).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 512
+    events with data out of 2,827 total wildfire events (2005-2012)., Observed persons
+    injured or made sick directly by disaster events from coastal flood (SURGE) events
+    in Indonesia. DesInventar records: 18 events with data out of 270 total coastal
+    flood events (2009-2011)., Observed persons injured or made sick directly by disaster
+    events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records:
+    169 events with data out of 449 total earthquake events (1976-2004)., Observed
+    persons injured or made sick directly by disaster events from tsunami (TSUNAMI)
+    events in Indonesia. DesInventar records: 3 events with data out of 13 total tsunami
+    events (1973-1977)., Observed persons injured or made sick directly by disaster
+    events from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records:
+    166 events with data out of 2,827 total wildfire events (2005-2012)., Observed
+    persons missing or unaccounted for after disaster events from coastal flood (SURGE)
+    events in Indonesia. DesInventar records: 7 events with data out of 270 total
+    coastal flood events (2009-2011)., Observed persons missing or unaccounted for
+    after disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
+    records: 10 events with data out of 449 total earthquake events (1976-2004).,
+    Observed persons missing or unaccounted for after disaster events from tsunami
+    (TSUNAMI) events in Indonesia. DesInventar records: 6 events with data out of
+    13 total tsunami events (1973-1977)., Observed persons missing or unaccounted
+    for after disaster events from wildfire (FIRE, FOREST FIRE) events in Indonesia.
+    DesInventar records: 5 events with data out of 2,827 total wildfire events (2005-2012).,
+    Observed persons temporarily evacuated from homes or workplaces from coastal flood
+    (SURGE) events in Indonesia. DesInventar records: 54 events with data out of 270
+    total coastal flood events (2009-2011)., Observed persons temporarily evacuated
+    from homes or workplaces from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
+    records: 103 events with data out of 449 total earthquake events (1976-2004).,
+    Observed persons temporarily evacuated from homes or workplaces from tsunami (TSUNAMI)
+    events in Indonesia. DesInventar records: 2 events with data out of 13 total tsunami
+    events (1973-1977)., Observed persons temporarily evacuated from homes or workplaces
+    from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 465
+    events with data out of 2,827 total wildfire events (2005-2012)., Observed total
+    economic losses in local currency from coastal flood (SURGE) events in Indonesia.
+    DesInventar records: 38 events with data out of 270 total coastal flood events
+    (2009-2011)., Observed total economic losses in local currency from drought (DROUGHT)
+    events in Indonesia. DesInventar records: 8 events with data out of 1,748 total
+    drought events (2004-2008)., Observed total economic losses in local currency
+    from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 32 events
+    with data out of 449 total earthquake events (1976-2004)., Observed total economic
+    losses in local currency from wildfire (FIRE, FOREST FIRE) events in Indonesia.
+    DesInventar records: 1,310 events with data out of 2,827 total wildfire events
+    (2005-2012).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: ground_motion, meteorological_drought, storm_surge, tsunami, wildfire
+  hazard_type: coastal_flood, drought, earthquake, tsunami, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Indonesia from the DesInventar
+  national disaster loss inventory, supporting disaster risk reduction monitoring
+  under the Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: DesInventar disaster loss data for Indonesia
+  download_url: https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366/resource/71c78d9f-b219-4881-8c1d-f79654b8c32b/download/idn.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: IDN.zip
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate
+    change event
+  download_url: https://data.humdata.org/dataset/6abc5323-7218-4592-9ab3-70c7e659f366/resource/bc3bc1c5-89ff-4777-9299-dbd2d09e2033/download/indonesia.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims
+    Affected, Relocated, Evacuated, Losses and Damages in crops by climate change
+    event
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-idnundrr_desinventar
+spatial:
+  bbox:
+  - 95.01
+  - -10.92
+  - 140.98
+  - 5.91
+  countries:
+  - IDN
+  gazetteer_entries:
+  - description: Indonesia
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/1643084/indonesia.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Indonesia
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-kenundrr_desinventar.md
+++ b/_datasets/rdls_lss-kenundrr_desinventar.md
@@ -1,0 +1,236 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: National Disaster Operations Centre (NDOC)
+  url: https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-kenundrr_desinventar
+description: 'National disaster loss inventory for Kenya from the DesInventar Sendai
+  Framework Monitor database, compiled by National Disaster Operations Centre (NDOC)
+  and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 1,857 event-level loss records covering 1997-2016, with observed impacts
+  from convective_storm, drought, flood, landslide, strong_wind, wildfire events.
+  Loss data includes human casualties, displacement, building damage, economic losses,
+  agricultural damage, and infrastructure impacts. [Source: This metadata record was
+  automatically extracted from the Humanitarian Data Exchange (HDX) at https://data.humdata.org]
+  [Original dataset: https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d]'
+details: 'Event-level disaster loss records from the DesInventar database for Kenya,
+  maintained by National Disaster Operations Centre (NDOC). Covers 1,857 observed
+  disaster events from 1997-2016. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from convective
+    storm (THUNDERSTORM) events in Kenya. DesInventar records: 14 events with data
+    out of 19 total convective storm events (2011-2013)., Observed deaths directly
+    caused by disaster events from flood (FLOOD) events in Kenya. DesInventar records:
+    236 events with data out of 737 total flood events (2011-2014)., Observed deaths
+    directly caused by disaster events from flood (RAINS) events in Kenya. DesInventar
+    records: 6 events with data out of 48 total flood events (2015-2016)., Observed
+    deaths directly caused by disaster events from landslide (LANDSLIDE) events in
+    Kenya. DesInventar records: 26 events with data out of 44 total landslide events
+    (2013-2016)., Observed deaths directly caused by disaster events from landslide
+    (MUDSLIDE) events in Kenya. DesInventar records: 4 events with data out of 6 total
+    landslide events (2009-2015)., Observed deaths directly caused by disaster events
+    from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 6 events
+    with data out of 19 total strong wind events (2010-2015)., Observed deaths directly
+    caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar
+    records: 114 events with data out of 415 total wildfire events (1997-2016)., Observed
+    educational facilities destroyed or affected from convective storm (THUNDERSTORM)
+    events in Kenya. DesInventar records: 1 events with data out of 19 total convective
+    storm events (2011-2013)., Observed educational facilities destroyed or affected
+    from flood (FLOOD) events in Kenya. DesInventar records: 1 events with data out
+    of 737 total flood events (2011-2014)., Observed educational facilities destroyed
+    or affected from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records:
+    1 events with data out of 19 total strong wind events (2010-2015)., Observed hectares
+    of crops/woods destroyed or affected from flood (FLOOD) events in Kenya. DesInventar
+    records: 34 events with data out of 737 total flood events (2011-2014)., Observed
+    hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events
+    in Kenya. DesInventar records: 1 events with data out of 44 total landslide events
+    (2013-2016)., Observed hectares of crops/woods destroyed or affected from wildfire
+    (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 23 events with data
+    out of 415 total wildfire events (1997-2016)., Observed homes destroyed beyond
+    habitability from convective storm (THUNDERSTORM) events in Kenya. DesInventar
+    records: 1 events with data out of 19 total convective storm events (2011-2013).,
+    Observed homes destroyed beyond habitability from flood (FLOOD) events in Kenya.
+    DesInventar records: 136 events with data out of 737 total flood events (2011-2014).,
+    Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+    in Kenya. DesInventar records: 13 events with data out of 44 total landslide events
+    (2013-2016)., Observed homes destroyed beyond habitability from wildfire (FIRE,
+    FOREST FIRE) events in Kenya. DesInventar records: 69 events with data out of
+    415 total wildfire events (1997-2016)., Observed homes with non-structural damage,
+    still habitable from convective storm (THUNDERSTORM) events in Kenya. DesInventar
+    records: 1 events with data out of 19 total convective storm events (2011-2013).,
+    Observed homes with non-structural damage, still habitable from flood (FLOOD)
+    events in Kenya. DesInventar records: 32 events with data out of 737 total flood
+    events (2011-2014)., Observed homes with non-structural damage, still habitable
+    from flood (RAINS) events in Kenya. DesInventar records: 1 events with data out
+    of 48 total flood events (2015-2016)., Observed homes with non-structural damage,
+    still habitable from landslide (LANDSLIDE) events in Kenya. DesInventar records:
+    2 events with data out of 44 total landslide events (2013-2016)., Observed homes
+    with non-structural damage, still habitable from strong wind (STORM, WINDSTORM)
+    events in Kenya. DesInventar records: 4 events with data out of 19 total strong
+    wind events (2010-2015)., Observed homes with non-structural damage, still habitable
+    from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 15 events
+    with data out of 415 total wildfire events (1997-2016)., Observed livestock lost
+    from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 2 events
+    with data out of 19 total convective storm events (2011-2013)., Observed livestock
+    lost from drought (DROUGHT) events in Kenya. DesInventar records: 1 events with
+    data out of 569 total drought events (2009-2011)., Observed livestock lost from
+    flood (FLOOD) events in Kenya. DesInventar records: 20 events with data out of
+    737 total flood events (2011-2014)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from convective storm (THUNDERSTORM) events in Kenya.
+    DesInventar records: 1 events with data out of 19 total convective storm events
+    (2011-2013)., Observed persons indirectly affected (disruption to services, commerce,
+    work) from drought (DROUGHT) events in Kenya. DesInventar records: 165 events
+    with data out of 569 total drought events (2009-2011)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from flood (FLOOD) events in
+    Kenya. DesInventar records: 207 events with data out of 737 total flood events
+    (2011-2014)., Observed persons indirectly affected (disruption to services, commerce,
+    work) from landslide (LANDSLIDE) events in Kenya. DesInventar records: 11 events
+    with data out of 44 total landslide events (2013-2016)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from strong wind (STORM, WINDSTORM)
+    events in Kenya. DesInventar records: 5 events with data out of 19 total strong
+    wind events (2010-2015)., Observed persons indirectly affected (disruption to
+    services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar
+    records: 3 events with data out of 415 total wildfire events (1997-2016)., Observed
+    persons injured or made sick directly by disaster events from convective storm
+    (THUNDERSTORM) events in Kenya. DesInventar records: 7 events with data out of
+    19 total convective storm events (2011-2013)., Observed persons injured or made
+    sick directly by disaster events from flood (FLOOD) events in Kenya. DesInventar
+    records: 23 events with data out of 737 total flood events (2011-2014)., Observed
+    persons injured or made sick directly by disaster events from flood (RAINS) events
+    in Kenya. DesInventar records: 1 events with data out of 48 total flood events
+    (2015-2016)., Observed persons injured or made sick directly by disaster events
+    from landslide (LANDSLIDE) events in Kenya. DesInventar records: 5 events with
+    data out of 44 total landslide events (2013-2016)., Observed persons injured or
+    made sick directly by disaster events from landslide (MUDSLIDE) events in Kenya.
+    DesInventar records: 1 events with data out of 6 total landslide events (2009-2015).,
+    Observed persons injured or made sick directly by disaster events from strong
+    wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with data
+    out of 19 total strong wind events (2010-2015)., Observed persons injured or made
+    sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Kenya.
+    DesInventar records: 79 events with data out of 415 total wildfire events (1997-2016).,
+    Observed persons missing or unaccounted for after disaster events from convective
+    storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data
+    out of 19 total convective storm events (2011-2013)., Observed persons missing
+    or unaccounted for after disaster events from flood (FLOOD) events in Kenya. DesInventar
+    records: 9 events with data out of 737 total flood events (2011-2014)., Observed
+    persons missing or unaccounted for after disaster events from landslide (LANDSLIDE)
+    events in Kenya. DesInventar records: 1 events with data out of 44 total landslide
+    events (2013-2016)., Observed persons missing or unaccounted for after disaster
+    events from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records:
+    1 events with data out of 19 total strong wind events (2010-2015)., Observed persons
+    permanently relocated from homes from flood (FLOOD) events in Kenya. DesInventar
+    records: 14 events with data out of 737 total flood events (2011-2014)., Observed
+    persons permanently relocated from homes from landslide (LANDSLIDE) events in
+    Kenya. DesInventar records: 2 events with data out of 44 total landslide events
+    (2013-2016)., Observed persons permanently relocated from homes from wildfire
+    (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 1 events with data out
+    of 415 total wildfire events (1997-2016)., Observed persons temporarily evacuated
+    from homes or workplaces from flood (FLOOD) events in Kenya. DesInventar records:
+    9 events with data out of 737 total flood events (2011-2014)., Observed persons
+    whose goods/services suffered serious damage from drought (DROUGHT) events in
+    Kenya. DesInventar records: 2 events with data out of 569 total drought events
+    (2009-2011)., Observed persons whose goods/services suffered serious damage from
+    flood (FLOOD) events in Kenya. DesInventar records: 2 events with data out of
+    737 total flood events (2011-2014)., Observed persons whose goods/services suffered
+    serious damage from flood (RAINS) events in Kenya. DesInventar records: 38 events
+    with data out of 48 total flood events (2015-2016)., Observed total economic losses
+    in local currency from convective storm (THUNDERSTORM) events in Kenya. DesInventar
+    records: 1 events with data out of 19 total convective storm events (2011-2013).,
+    Observed total economic losses in local currency from flood (FLOOD) events in
+    Kenya. DesInventar records: 2 events with data out of 737 total flood events (2011-2014).,
+    Observed total economic losses in local currency from strong wind (STORM, WINDSTORM)
+    events in Kenya. DesInventar records: 1 events with data out of 19 total strong
+    wind events (2010-2015)., Observed total economic losses in local currency from
+    wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 16 events with
+    data out of 415 total wildfire events (1997-2016).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, landslide_general, landslide_mudflow,
+    meteorological_drought, pluvial_flood, tornado, wildfire
+  hazard_type: convective_storm, drought, flood, landslide, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Kenya from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Kenya
+  download_url: https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d/resource/4d984de9-cd1b-483c-a887-860c9cb7a7c8/download/kenya.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Kenya
+- coordinate_system: null
+  description: Disaster tabular data for Kenya
+  download_url: https://data.humdata.org/dataset/7debae59-b034-4e9a-9fb1-4f270e57435d/resource/e518eeff-0d26-4f7b-9ab8-47fdcd5865b8/download/di_report-kenya.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster tabular data for Kenya
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-kenundrr_desinventar
+spatial:
+  bbox:
+  - 33.89
+  - -4.68
+  - 41.89
+  - 5.03
+  countries:
+  - KEN
+  gazetteer_entries:
+  - description: Kenya
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/192950/kenya.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Kenya
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-khmundrr_desinventar.md
+++ b/_datasets/rdls_lss-khmundrr_desinventar.md
@@ -1,0 +1,202 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: National Committee for Disaster Management (NCDM)
+  url: https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-khmundrr_desinventar
+description: 'National disaster loss inventory for Cambodia from the DesInventar Sendai
+  Framework Monitor database, compiled by National Committee for Disaster Management
+  (NCDM) and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 7,957 event-level loss records covering 2009-2016, with observed impacts
+  from drought, flood, strong_wind, wildfire events. Loss data includes human casualties,
+  displacement, building damage, economic losses, agricultural damage, and infrastructure
+  impacts. [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738]'
+details: 'Event-level disaster loss records from the DesInventar database for Cambodia,
+  maintained by National Committee for Disaster Management (NCDM). Covers 7,957 observed
+  disaster events from 2009-2016. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from flood (Flood)
+    events in Cambodia. DesInventar records: 394 events with data out of 3,389 total
+    flood events (2011-2014)., Observed deaths directly caused by disaster events
+    from strong wind (Storm) events in Cambodia. DesInventar records: 58 events with
+    data out of 1,454 total strong wind events (2009-2016)., Observed deaths directly
+    caused by disaster events from wildfire (Fire) events in Cambodia. DesInventar
+    records: 53 events with data out of 1,814 total wildfire events (2013-2016).,
+    Observed educational facilities destroyed or affected from drought (Drought) events
+    in Cambodia. DesInventar records: 1 events with data out of 1,300 total drought
+    events (2011-2016)., Observed educational facilities destroyed or affected from
+    flood (Flood) events in Cambodia. DesInventar records: 59 events with data out
+    of 3,389 total flood events (2011-2014)., Observed educational facilities destroyed
+    or affected from strong wind (Storm) events in Cambodia. DesInventar records:
+    26 events with data out of 1,454 total strong wind events (2009-2016)., Observed
+    health facilities destroyed or affected from flood (Flood) events in Cambodia.
+    DesInventar records: 27 events with data out of 3,389 total flood events (2011-2014).,
+    Observed health facilities destroyed or affected from strong wind (Storm) events
+    in Cambodia. DesInventar records: 7 events with data out of 1,454 total strong
+    wind events (2009-2016)., Observed hectares of crops/woods destroyed or affected
+    from drought (Drought) events in Cambodia. DesInventar records: 552 events with
+    data out of 1,300 total drought events (2011-2016)., Observed hectares of crops/woods
+    destroyed or affected from flood (Flood) events in Cambodia. DesInventar records:
+    1,780 events with data out of 3,389 total flood events (2011-2014)., Observed
+    hectares of crops/woods destroyed or affected from strong wind (Storm) events
+    in Cambodia. DesInventar records: 13 events with data out of 1,454 total strong
+    wind events (2009-2016)., Observed hectares of crops/woods destroyed or affected
+    from wildfire (Fire) events in Cambodia. DesInventar records: 1 events with data
+    out of 1,814 total wildfire events (2013-2016)., Observed homes destroyed beyond
+    habitability from flood (Flood) events in Cambodia. DesInventar records: 184 events
+    with data out of 3,389 total flood events (2011-2014)., Observed homes destroyed
+    beyond habitability from strong wind (Storm) events in Cambodia. DesInventar records:
+    957 events with data out of 1,454 total strong wind events (2009-2016)., Observed
+    homes destroyed beyond habitability from wildfire (Fire) events in Cambodia. DesInventar
+    records: 1,249 events with data out of 1,814 total wildfire events (2013-2016).,
+    Observed homes with non-structural damage, still habitable from flood (Flood)
+    events in Cambodia. DesInventar records: 222 events with data out of 3,389 total
+    flood events (2011-2014)., Observed homes with non-structural damage, still habitable
+    from strong wind (Storm) events in Cambodia. DesInventar records: 787 events with
+    data out of 1,454 total strong wind events (2009-2016)., Observed homes with non-structural
+    damage, still habitable from wildfire (Fire) events in Cambodia. DesInventar records:
+    220 events with data out of 1,814 total wildfire events (2013-2016)., Observed
+    livestock lost from drought (Drought) events in Cambodia. DesInventar records:
+    2 events with data out of 1,300 total drought events (2011-2016)., Observed livestock
+    lost from flood (Flood) events in Cambodia. DesInventar records: 88 events with
+    data out of 3,389 total flood events (2011-2014)., Observed livestock lost from
+    strong wind (Storm) events in Cambodia. DesInventar records: 23 events with data
+    out of 1,454 total strong wind events (2009-2016)., Observed livestock lost from
+    wildfire (Fire) events in Cambodia. DesInventar records: 2 events with data out
+    of 1,814 total wildfire events (2013-2016)., Observed metres of transport networks
+    destroyed from drought (Drought) events in Cambodia. DesInventar records: 4 events
+    with data out of 1,300 total drought events (2011-2016)., Observed metres of transport
+    networks destroyed from flood (Flood) events in Cambodia. DesInventar records:
+    983 events with data out of 3,389 total flood events (2011-2014)., Observed metres
+    of transport networks destroyed from strong wind (Storm) events in Cambodia. DesInventar
+    records: 3 events with data out of 1,454 total strong wind events (2009-2016).,
+    Observed persons indirectly affected (disruption to services, commerce, work)
+    from drought (Drought) events in Cambodia. DesInventar records: 32 events with
+    data out of 1,300 total drought events (2011-2016)., Observed persons indirectly
+    affected (disruption to services, commerce, work) from strong wind (Storm) events
+    in Cambodia. DesInventar records: 4 events with data out of 1,454 total strong
+    wind events (2009-2016)., Observed persons indirectly affected (disruption to
+    services, commerce, work) from wildfire (Fire) events in Cambodia. DesInventar
+    records: 5 events with data out of 1,814 total wildfire events (2013-2016)., Observed
+    persons injured or made sick directly by disaster events from flood (Flood) events
+    in Cambodia. DesInventar records: 38 events with data out of 3,389 total flood
+    events (2011-2014)., Observed persons injured or made sick directly by disaster
+    events from strong wind (Storm) events in Cambodia. DesInventar records: 128 events
+    with data out of 1,454 total strong wind events (2009-2016)., Observed persons
+    injured or made sick directly by disaster events from wildfire (Fire) events in
+    Cambodia. DesInventar records: 46 events with data out of 1,814 total wildfire
+    events (2013-2016)., Observed persons missing or unaccounted for after disaster
+    events from strong wind (Storm) events in Cambodia. DesInventar records: 1 events
+    with data out of 1,454 total strong wind events (2009-2016)., Observed persons
+    permanently relocated from homes from flood (Flood) events in Cambodia. DesInventar
+    records: 15 events with data out of 3,389 total flood events (2011-2014)., Observed
+    persons temporarily evacuated from homes or workplaces from flood (Flood) events
+    in Cambodia. DesInventar records: 421 events with data out of 3,389 total flood
+    events (2011-2014)., Observed persons temporarily evacuated from homes or workplaces
+    from strong wind (Storm) events in Cambodia. DesInventar records: 2 events with
+    data out of 1,454 total strong wind events (2009-2016)., Observed persons temporarily
+    evacuated from homes or workplaces from wildfire (Fire) events in Cambodia. DesInventar
+    records: 2 events with data out of 1,814 total wildfire events (2013-2016)., Observed
+    persons whose goods/services suffered serious damage from drought (Drought) events
+    in Cambodia. DesInventar records: 334 events with data out of 1,300 total drought
+    events (2011-2016)., Observed persons whose goods/services suffered serious damage
+    from flood (Flood) events in Cambodia. DesInventar records: 1,546 events with
+    data out of 3,389 total flood events (2011-2014)., Observed persons whose goods/services
+    suffered serious damage from strong wind (Storm) events in Cambodia. DesInventar
+    records: 681 events with data out of 1,454 total strong wind events (2009-2016).,
+    Observed persons whose goods/services suffered serious damage from wildfire (Fire)
+    events in Cambodia. DesInventar records: 579 events with data out of 1,814 total
+    wildfire events (2013-2016)., Observed total economic losses in US Dollars from
+    wildfire (Fire) events in Cambodia. DesInventar records: 1 events with data out
+    of 1,814 total wildfire events (2013-2016).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, meteorological_drought, wildfire
+  hazard_type: drought, flood, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Cambodia from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Cambodia
+  download_url: https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738/resource/bbb63796-5079-45af-b461-6f8b085b91a9/download/camdodia.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Cambodia
+- coordinate_system: null
+  description: Disaster Tabular data for Cambodia
+  download_url: https://data.humdata.org/dataset/0fccd714-7418-4ce5-9632-bbe125681738/resource/484f981d-278f-4bf0-8581-1fc38d70232a/download/di_report-cambodia.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster Tabular data for Cambodia
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-khmundrr_desinventar
+spatial:
+  bbox:
+  - 102.31
+  - 10.42
+  - 107.61
+  - 14.7
+  countries:
+  - KHM
+  gazetteer_entries:
+  - description: Cambodia
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/1831722/cambodia.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Cambodia
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-lkaundrr_desinventar.md
+++ b/_datasets/rdls_lss-lkaundrr_desinventar.md
@@ -1,0 +1,273 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Disaster Management Centre (DMC)
+  url: https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-lkaundrr_desinventar
+description: 'National disaster loss inventory for Sri Lanka from the DesInventar
+  Sendai Framework Monitor database, compiled by Disaster Management Centre (DMC)
+  and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 17,729 event-level loss records covering historical, with observed impacts
+  from coastal_flood, convective_storm, drought, extreme_temperature, flood, landslide,
+  strong_wind, tsunami, wildfire events. Loss data includes human casualties, displacement,
+  building damage, economic losses, agricultural damage, and infrastructure impacts.
+  [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184]'
+details: 'Event-level disaster loss records from the DesInventar database for Sri
+  Lanka, maintained by Disaster Management Centre (DMC). Covers 17,729 observed disaster
+  events from historical. Data collected through direct observational reporting and
+  includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from coastal flood
+    (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 4 events with data
+    out of 40 total coastal flood events., Observed deaths directly caused by disaster
+    events from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records:
+    1 events with data out of 20 total convective storm events., Observed deaths directly
+    caused by disaster events from drought (DROUGHT) events in Sri Lanka. DesInventar
+    records: 1 events with data out of 2,242 total drought events., Observed deaths
+    directly caused by disaster events from flood (FLASH FLOOD, FLOOD) events in Sri
+    Lanka. DesInventar records: 252 events with data out of 6,828 total flood events.,
+    Observed deaths directly caused by disaster events from flood (RAINS) events in
+    Sri Lanka. DesInventar records: 23 events with data out of 2,533 total flood events.,
+    Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+    events in Sri Lanka. DesInventar records: 174 events with data out of 2,100 total
+    landslide events., Observed deaths directly caused by disaster events from strong
+    wind (CYCLONE) events in Sri Lanka. DesInventar records: 27 events with data out
+    of 164 total strong wind events., Observed deaths directly caused by disaster
+    events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 13 events
+    with data out of 89 total tsunami events., Observed deaths directly caused by
+    disaster events from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar
+    records: 61 events with data out of 3,697 total wildfire events., Observed educational
+    facilities destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Sri
+    Lanka. DesInventar records: 2 events with data out of 6,828 total flood events.,
+    Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD)
+    events in Sri Lanka. DesInventar records: 1 events with data out of 6,828 total
+    flood events., Observed hectares of crops/woods destroyed or affected from drought
+    (DROUGHT) events in Sri Lanka. DesInventar records: 97 events with data out of
+    2,242 total drought events., Observed hectares of crops/woods destroyed or affected
+    from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 5 events
+    with data out of 6,828 total flood events., Observed homes destroyed beyond habitability
+    from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records:
+    2 events with data out of 40 total coastal flood events., Observed homes destroyed
+    beyond habitability from convective storm (HAILSTORM) events in Sri Lanka. DesInventar
+    records: 1 events with data out of 20 total convective storm events., Observed
+    homes destroyed beyond habitability from drought (DROUGHT) events in Sri Lanka.
+    DesInventar records: 1 events with data out of 2,242 total drought events., Observed
+    homes destroyed beyond habitability from flood (FLASH FLOOD, FLOOD) events in
+    Sri Lanka. DesInventar records: 1,229 events with data out of 6,828 total flood
+    events., Observed homes destroyed beyond habitability from flood (RAINS) events
+    in Sri Lanka. DesInventar records: 198 events with data out of 2,533 total flood
+    events., Observed homes destroyed beyond habitability from landslide (LANDSLIDE)
+    events in Sri Lanka. DesInventar records: 316 events with data out of 2,100 total
+    landslide events., Observed homes destroyed beyond habitability from strong wind
+    (CYCLONE) events in Sri Lanka. DesInventar records: 36 events with data out of
+    164 total strong wind events., Observed homes destroyed beyond habitability from
+    strong wind (STORM) events in Sri Lanka. DesInventar records: 2 events with data
+    out of 4 total strong wind events., Observed homes destroyed beyond habitability
+    from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 57 events with
+    data out of 89 total tsunami events., Observed homes destroyed beyond habitability
+    from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 538
+    events with data out of 3,697 total wildfire events., Observed homes with non-structural
+    damage, still habitable from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka.
+    DesInventar records: 7 events with data out of 40 total coastal flood events.,
+    Observed homes with non-structural damage, still habitable from convective storm
+    (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of
+    20 total convective storm events., Observed homes with non-structural damage,
+    still habitable from drought (DROUGHT) events in Sri Lanka. DesInventar records:
+    3 events with data out of 2,242 total drought events., Observed homes with non-structural
+    damage, still habitable from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar
+    records: 2,297 events with data out of 6,828 total flood events., Observed homes
+    with non-structural damage, still habitable from flood (RAINS) events in Sri Lanka.
+    DesInventar records: 1,829 events with data out of 2,533 total flood events.,
+    Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+    events in Sri Lanka. DesInventar records: 1,067 events with data out of 2,100
+    total landslide events., Observed homes with non-structural damage, still habitable
+    from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 106 events
+    with data out of 164 total strong wind events., Observed homes with non-structural
+    damage, still habitable from strong wind (STORM) events in Sri Lanka. DesInventar
+    records: 2 events with data out of 4 total strong wind events., Observed homes
+    with non-structural damage, still habitable from tsunami (TSUNAMI) events in Sri
+    Lanka. DesInventar records: 57 events with data out of 89 total tsunami events.,
+    Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+    FOREST FIRE) events in Sri Lanka. DesInventar records: 423 events with data out
+    of 3,697 total wildfire events., Observed persons indirectly affected (disruption
+    to services, commerce, work) from coastal flood (SURGE, TIDAL WAVE) events in
+    Sri Lanka. DesInventar records: 20 events with data out of 40 total coastal flood
+    events., Observed persons indirectly affected (disruption to services, commerce,
+    work) from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records:
+    1 events with data out of 20 total convective storm events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from drought (DROUGHT)
+    events in Sri Lanka. DesInventar records: 1,327 events with data out of 2,242
+    total drought events., Observed persons indirectly affected (disruption to services,
+    commerce, work) from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar
+    records: 5,541 events with data out of 6,828 total flood events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from flood (RAINS)
+    events in Sri Lanka. DesInventar records: 2,405 events with data out of 2,533
+    total flood events., Observed persons indirectly affected (disruption to services,
+    commerce, work) from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records:
+    1,545 events with data out of 2,100 total landslide events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from strong wind
+    (CYCLONE) events in Sri Lanka. DesInventar records: 117 events with data out of
+    164 total strong wind events., Observed persons indirectly affected (disruption
+    to services, commerce, work) from strong wind (STORM) events in Sri Lanka. DesInventar
+    records: 2 events with data out of 4 total strong wind events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from tsunami (TSUNAMI)
+    events in Sri Lanka. DesInventar records: 69 events with data out of 89 total
+    tsunami events., Observed persons indirectly affected (disruption to services,
+    commerce, work) from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar
+    records: 983 events with data out of 3,697 total wildfire events., Observed persons
+    injured or made sick directly by disaster events from convective storm (HAILSTORM)
+    events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective
+    storm events., Observed persons injured or made sick directly by disaster events
+    from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 80 events
+    with data out of 6,828 total flood events., Observed persons injured or made sick
+    directly by disaster events from flood (RAINS) events in Sri Lanka. DesInventar
+    records: 17 events with data out of 2,533 total flood events., Observed persons
+    injured or made sick directly by disaster events from landslide (LANDSLIDE) events
+    in Sri Lanka. DesInventar records: 125 events with data out of 2,100 total landslide
+    events., Observed persons injured or made sick directly by disaster events from
+    strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 16 events with
+    data out of 164 total strong wind events., Observed persons injured or made sick
+    directly by disaster events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar
+    records: 40 events with data out of 89 total tsunami events., Observed persons
+    injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE)
+    events in Sri Lanka. DesInventar records: 36 events with data out of 3,697 total
+    wildfire events., Observed persons missing or unaccounted for after disaster events
+    from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with
+    data out of 2,242 total drought events., Observed persons missing or unaccounted
+    for after disaster events from flood (FLASH FLOOD, FLOOD) events in Sri Lanka.
+    DesInventar records: 10 events with data out of 6,828 total flood events., Observed
+    persons missing or unaccounted for after disaster events from flood (RAINS) events
+    in Sri Lanka. DesInventar records: 1 events with data out of 2,533 total flood
+    events., Observed persons missing or unaccounted for after disaster events from
+    landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with
+    data out of 2,100 total landslide events., Observed persons missing or unaccounted
+    for after disaster events from strong wind (CYCLONE) events in Sri Lanka. DesInventar
+    records: 2 events with data out of 164 total strong wind events., Observed persons
+    missing or unaccounted for after disaster events from tsunami (TSUNAMI) events
+    in Sri Lanka. DesInventar records: 35 events with data out of 89 total tsunami
+    events., Observed persons permanently relocated from homes from flood (FLASH FLOOD,
+    FLOOD) events in Sri Lanka. DesInventar records: 5 events with data out of 6,828
+    total flood events., Observed persons permanently relocated from homes from flood
+    (RAINS) events in Sri Lanka. DesInventar records: 1 events with data out of 2,533
+    total flood events., Observed persons permanently relocated from homes from landslide
+    (LANDSLIDE) events in Sri Lanka. DesInventar records: 8 events with data out of
+    2,100 total landslide events., Observed persons temporarily evacuated from homes
+    or workplaces from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar
+    records: 1 events with data out of 40 total coastal flood events., Observed persons
+    temporarily evacuated from homes or workplaces from drought (DROUGHT) events in
+    Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought
+    events., Observed persons temporarily evacuated from homes or workplaces from
+    flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 82 events
+    with data out of 6,828 total flood events., Observed persons temporarily evacuated
+    from homes or workplaces from flood (RAINS) events in Sri Lanka. DesInventar records:
+    19 events with data out of 2,533 total flood events., Observed persons temporarily
+    evacuated from homes or workplaces from landslide (LANDSLIDE) events in Sri Lanka.
+    DesInventar records: 46 events with data out of 2,100 total landslide events.,
+    Observed persons temporarily evacuated from homes or workplaces from strong wind
+    (CYCLONE) events in Sri Lanka. DesInventar records: 4 events with data out of
+    164 total strong wind events., Observed persons temporarily evacuated from homes
+    or workplaces from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar
+    records: 16 events with data out of 3,697 total wildfire events., Observed persons
+    whose goods/services suffered serious damage from flood (FLASH FLOOD, FLOOD) events
+    in Sri Lanka. DesInventar records: 2 events with data out of 6,828 total flood
+    events., Observed total economic losses in local currency from flood (FLASH FLOOD,
+    FLOOD) events in Sri Lanka. DesInventar records: 7 events with data out of 6,828
+    total flood events., Observed total economic losses in local currency from landslide
+    (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with data out of
+    2,100 total landslide events., Observed total economic losses in local currency
+    from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 3 events with
+    data out of 89 total tsunami events., Observed total economic losses in local
+    currency from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records:
+    3 events with data out of 3,697 total wildfire events.'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, landslide_general, meteorological_drought,
+    pluvial_flood, storm_surge, tornado, tropical_cyclone, tsunami, wildfire
+  hazard_type: coastal_flood, convective_storm, drought, flood, landslide, strong_wind,
+    tsunami, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Sri Lanka from the DesInventar
+  national disaster loss inventory, supporting disaster risk reduction monitoring
+  under the Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Sri Lanka
+  download_url: https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184/resource/49adba32-509f-49e7-b63e-928ef743c52e/download/srilanka.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Sri Lanka
+- coordinate_system: null
+  description: Disaster tabular data for Sri Lanka
+  download_url: https://data.humdata.org/dataset/08c9ca36-8b95-4361-abf1-ce21bfc49184/resource/4cb4bd14-e5ba-4443-af23-948bfb05f479/download/di_report-srilanka.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster tabular data for Sri Lanka
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-lkaundrr_desinventar
+spatial:
+  bbox:
+  - 79.66
+  - 5.92
+  - 81.89
+  - 9.83
+  countries:
+  - LKA
+  gazetteer_entries:
+  - description: Sri Lanka
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/1227603/sri-lanka.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Sri Lanka
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-mdgundrr_desinventar_a.md
+++ b/_datasets/rdls_lss-mdgundrr_desinventar_a.md
@@ -1,0 +1,139 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Cellule de Prevention et Gestion des Urgences (CPGU)
+  url: https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-mdgundrr_desinventar_a
+description: 'National disaster loss inventory for Madagascar from the DesInventar
+  Sendai Framework Monitor database, compiled by Cellule de Prevention et Gestion
+  des Urgences (CPGU) and published by the United Nations Office for Disaster Risk
+  Reduction (UNDRR). Contains 227 event-level loss records covering 2009-2009, with
+  observed impacts from flood, wildfire events. Loss data includes human casualties,
+  displacement, building damage, economic losses, agricultural damage, and infrastructure
+  impacts. [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff]'
+details: 'Event-level disaster loss records from the DesInventar database for Madagascar,
+  maintained by Cellule de Prevention et Gestion des Urgences (CPGU). Covers 227 observed
+  disaster events from 2009-2009. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from flood (FLOOD)
+    events in Madagascar. DesInventar records: 2 events with data out of 9 total flood
+    events., Observed deaths directly caused by disaster events from wildfire (FIRE)
+    events in Madagascar. DesInventar records: 14 events with data out of 218 total
+    wildfire events (2009-2009)., Observed educational facilities destroyed or affected
+    from wildfire (FIRE) events in Madagascar. DesInventar records: 9 events with
+    data out of 218 total wildfire events (2009-2009)., Observed hectares of crops/woods
+    destroyed or affected from flood (FLOOD) events in Madagascar. DesInventar records:
+    4 events with data out of 9 total flood events., Observed homes destroyed beyond
+    habitability from flood (FLOOD) events in Madagascar. DesInventar records: 4 events
+    with data out of 9 total flood events., Observed homes destroyed beyond habitability
+    from wildfire (FIRE) events in Madagascar. DesInventar records: 198 events with
+    data out of 218 total wildfire events (2009-2009)., Observed homes with non-structural
+    damage, still habitable from wildfire (FIRE) events in Madagascar. DesInventar
+    records: 1 events with data out of 218 total wildfire events (2009-2009)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from flood
+    (FLOOD) events in Madagascar. DesInventar records: 9 events with data out of 9
+    total flood events., Observed persons indirectly affected (disruption to services,
+    commerce, work) from wildfire (FIRE) events in Madagascar. DesInventar records:
+    159 events with data out of 218 total wildfire events (2009-2009)., Observed persons
+    injured or made sick directly by disaster events from wildfire (FIRE) events in
+    Madagascar. DesInventar records: 24 events with data out of 218 total wildfire
+    events (2009-2009)., Observed persons whose goods/services suffered serious damage
+    from flood (FLOOD) events in Madagascar. DesInventar records: 9 events with data
+    out of 9 total flood events., Observed persons whose goods/services suffered serious
+    damage from wildfire (FIRE) events in Madagascar. DesInventar records: 136 events
+    with data out of 218 total wildfire events (2009-2009).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: fluvial_flood, wildfire
+  hazard_type: flood, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Madagascar from the DesInventar
+  national disaster loss inventory, supporting disaster risk reduction monitoring
+  under the Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate
+    change event
+  download_url: https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff/resource/7775fc9a-2f75-4015-85e7-1d5943a9d2ce/download/madagascar.xlsx
+  format: Excel (xlsx)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims
+    Affected, Relocated, Evacuated, Losses and Damages in crops by climate change
+    event
+- coordinate_system: null
+  description: DesInventar disaster loss data for Madagascar
+  download_url: https://data.humdata.org/dataset/b2bac671-00d7-4303-8cbe-046c90b159ff/resource/0090e8a4-8500-44e9-9ca8-659cf30ea97b/download/madagascar.zip
+  format: Shapefile (shp)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Madagascar.zip
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-mdgundrr_desinventar_a
+spatial:
+  bbox:
+  - 43.22
+  - -25.6
+  - 50.5
+  - -11.94
+  countries:
+  - MDG
+  gazetteer_entries:
+  - description: Madagascar
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/1062947/madagascar.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Madagascar
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-mdgundrr_desinventar_b.md
+++ b/_datasets/rdls_lss-mdgundrr_desinventar_b.md
@@ -1,0 +1,148 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Cellule de Prevention et Gestion des Urgences (CPGU)
+  url: https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-mdgundrr_desinventar_b
+description: 'National disaster loss inventory for Madagascar from the DesInventar
+  Sendai Framework Monitor database, compiled by Cellule de Prevention et Gestion
+  des Urgences (CPGU) and published by the United Nations Office for Disaster Risk
+  Reduction (UNDRR). Contains 244 event-level loss records covering 2008-2015, with
+  observed impacts from drought, flood, landslide, wildfire events. Loss data includes
+  human casualties, displacement, building damage, economic losses, agricultural damage,
+  and infrastructure impacts. [Source: This metadata record was automatically extracted
+  from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original
+  dataset: https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2]'
+details: 'Event-level disaster loss records from the DesInventar database for Madagascar,
+  maintained by Cellule de Prevention et Gestion des Urgences (CPGU). Covers 244 observed
+  disaster events from 2008-2015. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from drought (DROUGHT)
+    events in Madagascar. DesInventar records: 3 events with data out of 3 total drought
+    events (2015-2015)., Observed deaths directly caused by disaster events from flood
+    (FLOOD) events in Madagascar. DesInventar records: 8 events with data out of 20
+    total flood events (2008-2015)., Observed deaths directly caused by disaster events
+    from landslide (LANDSLIDE) events in Madagascar. DesInventar records: 2 events
+    with data out of 2 total landslide events (2015-2015)., Observed deaths directly
+    caused by disaster events from wildfire (FIRE) events in Madagascar. DesInventar
+    records: 14 events with data out of 219 total wildfire events (2009-2015)., Observed
+    educational facilities destroyed or affected from wildfire (FIRE) events in Madagascar.
+    DesInventar records: 9 events with data out of 219 total wildfire events (2009-2015).,
+    Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+    in Madagascar. DesInventar records: 9 events with data out of 20 total flood events
+    (2008-2015)., Observed homes destroyed beyond habitability from flood (FLOOD)
+    events in Madagascar. DesInventar records: 10 events with data out of 20 total
+    flood events (2008-2015)., Observed homes destroyed beyond habitability from landslide
+    (LANDSLIDE) events in Madagascar. DesInventar records: 2 events with data out
+    of 2 total landslide events (2015-2015)., Observed homes destroyed beyond habitability
+    from wildfire (FIRE) events in Madagascar. DesInventar records: 199 events with
+    data out of 219 total wildfire events (2009-2015)., Observed homes with non-structural
+    damage, still habitable from wildfire (FIRE) events in Madagascar. DesInventar
+    records: 1 events with data out of 219 total wildfire events (2009-2015)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from flood
+    (FLOOD) events in Madagascar. DesInventar records: 19 events with data out of
+    20 total flood events (2008-2015)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from wildfire (FIRE) events in Madagascar. DesInventar
+    records: 159 events with data out of 219 total wildfire events (2009-2015)., Observed
+    persons injured or made sick directly by disaster events from wildfire (FIRE)
+    events in Madagascar. DesInventar records: 24 events with data out of 219 total
+    wildfire events (2009-2015)., Observed persons permanently relocated from homes
+    from flood (FLOOD) events in Madagascar. DesInventar records: 7 events with data
+    out of 20 total flood events (2008-2015)., Observed persons whose goods/services
+    suffered serious damage from flood (FLOOD) events in Madagascar. DesInventar records:
+    19 events with data out of 20 total flood events (2008-2015)., Observed persons
+    whose goods/services suffered serious damage from landslide (LANDSLIDE) events
+    in Madagascar. DesInventar records: 1 events with data out of 2 total landslide
+    events (2015-2015)., Observed persons whose goods/services suffered serious damage
+    from wildfire (FIRE) events in Madagascar. DesInventar records: 137 events with
+    data out of 219 total wildfire events (2009-2015).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: fluvial_flood, landslide_general, meteorological_drought, wildfire
+  hazard_type: drought, flood, landslide, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Madagascar from the DesInventar
+  national disaster loss inventory, supporting disaster risk reduction monitoring
+  under the Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Madagascar
+  download_url: https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2/resource/0250ddbb-b0ad-4fad-a716-e7f26fbd0164/download/madagascar.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Madagascar
+- coordinate_system: null
+  description: Disaster tabular data for Madagascar
+  download_url: https://data.humdata.org/dataset/7e62f19b-805c-44cb-8030-bd14275bd7b2/resource/11f149bb-31df-42e4-b47d-0b18216e9f2d/download/di_report-madagascar.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster tabular data for Madagascar
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-mdgundrr_desinventar_b
+spatial:
+  bbox:
+  - 43.22
+  - -25.6
+  - 50.5
+  - -11.94
+  countries:
+  - MDG
+  gazetteer_entries:
+  - description: Madagascar
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/1062947/madagascar.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Madagascar
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-mliundrr_desinventar.md
+++ b/_datasets/rdls_lss-mliundrr_desinventar.md
@@ -1,0 +1,185 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Direction Nationale de la Protection Civile
+  url: https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-mliundrr_desinventar
+description: 'National disaster loss inventory for Mali from the DesInventar Sendai
+  Framework Monitor database, compiled by Direction Nationale de la Protection Civile
+  and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 1,718 event-level loss records covering 2005-2011, with observed impacts
+  from convective_storm, drought, flood, strong_wind, wildfire events. Loss data includes
+  human casualties, displacement, building damage, economic losses, agricultural damage,
+  and infrastructure impacts. [Source: This metadata record was automatically extracted
+  from the Humanitarian Data Exchange (HDX) at https://data.humdata.org] [Original
+  dataset: https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796]'
+details: 'Event-level disaster loss records from the DesInventar database for Mali,
+  maintained by Direction Nationale de la Protection Civile. Covers 1,718 observed
+  disaster events from 2005-2011. Data collected through direct observational reporting
+  and includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from convective
+    storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 5 events
+    with data out of 9 total convective storm events (2005-2005)., Observed deaths
+    directly caused by disaster events from flood (FLOOD) events in Mali. DesInventar
+    records: 119 events with data out of 833 total flood events., Observed educational
+    facilities destroyed or affected from flood (FLOOD) events in Mali. DesInventar
+    records: 14 events with data out of 833 total flood events., Observed hectares
+    of crops/woods destroyed or affected from flood (FLOOD) events in Mali. DesInventar
+    records: 115 events with data out of 833 total flood events., Observed hectares
+    of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events
+    in Mali. DesInventar records: 41 events with data out of 58 total wildfire events
+    (2008-2011)., Observed homes destroyed beyond habitability from convective storm
+    (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 1 events with data
+    out of 9 total convective storm events (2005-2005)., Observed homes destroyed
+    beyond habitability from flood (FLOOD) events in Mali. DesInventar records: 438
+    events with data out of 833 total flood events., Observed homes destroyed beyond
+    habitability from strong wind (WINDSTORM) events in Mali. DesInventar records:
+    1 events with data out of 2 total strong wind events., Observed homes destroyed
+    beyond habitability from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar
+    records: 2 events with data out of 58 total wildfire events (2008-2011)., Observed
+    homes with non-structural damage, still habitable from flood (FLOOD) events in
+    Mali. DesInventar records: 143 events with data out of 833 total flood events.,
+    Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+    FOREST FIRE) events in Mali. DesInventar records: 2 events with data out of 58
+    total wildfire events (2008-2011)., Observed livestock lost from convective storm
+    (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 2 events with data
+    out of 9 total convective storm events (2005-2005)., Observed livestock lost from
+    drought (DROUGHT) events in Mali. DesInventar records: 2 events with data out
+    of 816 total drought events., Observed livestock lost from flood (FLOOD) events
+    in Mali. DesInventar records: 128 events with data out of 833 total flood events.,
+    Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar
+    records: 5 events with data out of 58 total wildfire events (2008-2011)., Observed
+    metres of transport networks destroyed from flood (FLOOD) events in Mali. DesInventar
+    records: 6 events with data out of 833 total flood events., Observed persons indirectly
+    affected (disruption to services, commerce, work) from convective storm (HAILSTORM,
+    THUNDERSTORM) events in Mali. DesInventar records: 2 events with data out of 9
+    total convective storm events (2005-2005)., Observed persons indirectly affected
+    (disruption to services, commerce, work) from drought (DROUGHT) events in Mali.
+    DesInventar records: 812 events with data out of 816 total drought events., Observed
+    persons indirectly affected (disruption to services, commerce, work) from flood
+    (FLOOD) events in Mali. DesInventar records: 38 events with data out of 833 total
+    flood events., Observed persons indirectly affected (disruption to services, commerce,
+    work) from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 2
+    events with data out of 58 total wildfire events (2008-2011)., Observed persons
+    injured or made sick directly by disaster events from convective storm (HAILSTORM,
+    THUNDERSTORM) events in Mali. DesInventar records: 1 events with data out of 9
+    total convective storm events (2005-2005)., Observed persons injured or made sick
+    directly by disaster events from flood (FLOOD) events in Mali. DesInventar records:
+    99 events with data out of 833 total flood events., Observed persons injured or
+    made sick directly by disaster events from strong wind (WINDSTORM) events in Mali.
+    DesInventar records: 1 events with data out of 2 total strong wind events., Observed
+    persons injured or made sick directly by disaster events from wildfire (FIRE,
+    FOREST FIRE) events in Mali. DesInventar records: 3 events with data out of 58
+    total wildfire events (2008-2011)., Observed persons missing or unaccounted for
+    after disaster events from flood (FLOOD) events in Mali. DesInventar records:
+    8 events with data out of 833 total flood events., Observed persons permanently
+    relocated from homes from flood (FLOOD) events in Mali. DesInventar records: 23
+    events with data out of 833 total flood events., Observed persons temporarily
+    evacuated from homes or workplaces from flood (FLOOD) events in Mali. DesInventar
+    records: 1 events with data out of 833 total flood events., Observed persons whose
+    goods/services suffered serious damage from drought (DROUGHT) events in Mali.
+    DesInventar records: 1 events with data out of 816 total drought events., Observed
+    persons whose goods/services suffered serious damage from flood (FLOOD) events
+    in Mali. DesInventar records: 544 events with data out of 833 total flood events.,
+    Observed persons whose goods/services suffered serious damage from strong wind
+    (WINDSTORM) events in Mali. DesInventar records: 1 events with data out of 2 total
+    strong wind events., Observed persons whose goods/services suffered serious damage
+    from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 1 events
+    with data out of 58 total wildfire events (2008-2011)., Observed total economic
+    losses in local currency from flood (FLOOD) events in Mali. DesInventar records:
+    84 events with data out of 833 total flood events.'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, meteorological_drought, tornado,
+    wildfire
+  hazard_type: convective_storm, drought, flood, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Mali from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate
+    change event
+  download_url: https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796/resource/b9e494bf-b6e6-4777-8745-9d55d86744f9/download/mali.xlsx
+  format: Excel (xlsx)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims
+    Affected, Relocated, Evacuated, Losses and Damages in crops by climate change
+    event
+- coordinate_system: null
+  description: DesInventar disaster loss data for Mali
+  download_url: https://data.humdata.org/dataset/19ed73b5-9f91-4568-a0f3-48b7fa8c1796/resource/2aac7c1d-8d30-41e1-b6d3-42a8cbcb0594/download/mali.zip
+  format: Shapefile (shp)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Mali.zip
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-mliundrr_desinventar
+spatial:
+  bbox:
+  - -12.26
+  - 10.14
+  - 4.24
+  - 25.0
+  countries:
+  - MLI
+  gazetteer_entries:
+  - description: Mali
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/2453866/mali.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Mali
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-nerundrr_desinventar_a.md
+++ b/_datasets/rdls_lss-nerundrr_desinventar_a.md
@@ -1,0 +1,173 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Systeme d'Alerte Precoce (SAP)
+  url: https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-nerundrr_desinventar_a
+description: 'National disaster loss inventory for Niger from the DesInventar Sendai
+  Framework Monitor database, compiled by Systeme d''Alerte Precoce (SAP) and published
+  by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 1,362
+  event-level loss records covering historical, with observed impacts from drought,
+  flood, wildfire events. Loss data includes human casualties, displacement, building
+  damage, economic losses, agricultural damage, and infrastructure impacts. [Source:
+  This metadata record was automatically extracted from the Humanitarian Data Exchange
+  (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853]'
+details: 'Event-level disaster loss records from the DesInventar database for Niger,
+  maintained by Systeme d''Alerte Precoce (SAP). Covers 1,362 observed disaster events
+  from historical. Data collected through direct observational reporting and includes
+  human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical
+  impacts (houses destroyed/damaged, education centres, hospitals, roads), economic
+  losses (local currency and USD), and agricultural impacts (crop damage in hectares,
+  livestock losses). Methodology: Direct Observational Data / Anecdotal Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from drought (DROUGHT)
+    events in Niger. DesInventar records: 2 events with data out of 289 total drought
+    events., Observed deaths directly caused by disaster events from flood (FLOOD)
+    events in Niger. DesInventar records: 49 events with data out of 763 total flood
+    events., Observed deaths directly caused by disaster events from wildfire (FIRE,
+    FOREST FIRE) events in Niger. DesInventar records: 23 events with data out of
+    310 total wildfire events., Observed educational facilities destroyed or affected
+    from flood (FLOOD) events in Niger. DesInventar records: 5 events with data out
+    of 763 total flood events., Observed educational facilities destroyed or affected
+    from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events
+    with data out of 310 total wildfire events., Observed health facilities destroyed
+    or affected from flood (FLOOD) events in Niger. DesInventar records: 1 events
+    with data out of 763 total flood events., Observed hectares of crops/woods destroyed
+    or affected from drought (DROUGHT) events in Niger. DesInventar records: 15 events
+    with data out of 289 total drought events., Observed hectares of crops/woods destroyed
+    or affected from flood (FLOOD) events in Niger. DesInventar records: 239 events
+    with data out of 763 total flood events., Observed hectares of crops/woods destroyed
+    or affected from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records:
+    168 events with data out of 310 total wildfire events., Observed homes destroyed
+    beyond habitability from flood (FLOOD) events in Niger. DesInventar records: 410
+    events with data out of 763 total flood events., Observed homes destroyed beyond
+    habitability from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records:
+    28 events with data out of 310 total wildfire events., Observed homes with non-structural
+    damage, still habitable from flood (FLOOD) events in Niger. DesInventar records:
+    29 events with data out of 763 total flood events., Observed homes with non-structural
+    damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
+    records: 2 events with data out of 310 total wildfire events., Observed livestock
+    lost from drought (DROUGHT) events in Niger. DesInventar records: 14 events with
+    data out of 289 total drought events., Observed livestock lost from flood (FLOOD)
+    events in Niger. DesInventar records: 122 events with data out of 763 total flood
+    events., Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger.
+    DesInventar records: 14 events with data out of 310 total wildfire events., Observed
+    persons indirectly affected (disruption to services, commerce, work) from drought
+    (DROUGHT) events in Niger. DesInventar records: 46 events with data out of 289
+    total drought events., Observed persons indirectly affected (disruption to services,
+    commerce, work) from flood (FLOOD) events in Niger. DesInventar records: 214 events
+    with data out of 763 total flood events., Observed persons indirectly affected
+    (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events
+    in Niger. DesInventar records: 78 events with data out of 310 total wildfire events.,
+    Observed persons injured or made sick directly by disaster events from flood (FLOOD)
+    events in Niger. DesInventar records: 34 events with data out of 763 total flood
+    events., Observed persons permanently relocated from homes from drought (DROUGHT)
+    events in Niger. DesInventar records: 10 events with data out of 289 total drought
+    events., Observed persons permanently relocated from homes from flood (FLOOD)
+    events in Niger. DesInventar records: 2 events with data out of 763 total flood
+    events., Observed persons whose goods/services suffered serious damage from drought
+    (DROUGHT) events in Niger. DesInventar records: 143 events with data out of 289
+    total drought events., Observed persons whose goods/services suffered serious
+    damage from flood (FLOOD) events in Niger. DesInventar records: 456 events with
+    data out of 763 total flood events., Observed persons whose goods/services suffered
+    serious damage from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
+    records: 48 events with data out of 310 total wildfire events., Observed total
+    economic losses in US Dollars from flood (FLOOD) events in Niger. DesInventar
+    records: 1 events with data out of 763 total flood events., Observed total economic
+    losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
+    records: 2 events with data out of 310 total wildfire events., Observed total
+    economic losses in local currency from drought (DROUGHT) events in Niger. DesInventar
+    records: 6 events with data out of 289 total drought events., Observed total economic
+    losses in local currency from flood (FLOOD) events in Niger. DesInventar records:
+    9 events with data out of 763 total flood events., Observed total economic losses
+    in local currency from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
+    records: 14 events with data out of 310 total wildfire events.'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: fluvial_flood, meteorological_drought, wildfire
+  hazard_type: drought, flood, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Niger from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate
+    change event
+  download_url: https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853/resource/9b9d4019-129f-4df2-9499-09558b893bf8/download/niger.xlsx
+  format: Excel (xlsx)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims
+    Affected, Relocated, Evacuated, Losses and Damages in crops by climate change
+    event
+- coordinate_system: null
+  description: DesInventar disaster loss data for Niger
+  download_url: https://data.humdata.org/dataset/d16485d0-2011-4f5d-bb12-9e92feb8f853/resource/d6b6609d-3e6d-41f9-b14b-d6f4035d2d56/download/niger.zip
+  format: Shapefile (shp)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Niger.zip
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-nerundrr_desinventar_a
+spatial:
+  bbox:
+  - 0.15
+  - 11.7
+  - 15.97
+  - 23.52
+  countries:
+  - NER
+  gazetteer_entries:
+  - description: Niger
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/2440476/niger.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Niger
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-nerundrr_desinventar_b.md
+++ b/_datasets/rdls_lss-nerundrr_desinventar_b.md
@@ -1,0 +1,174 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Systeme d'Alerte Precoce (SAP)
+  url: https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-nerundrr_desinventar_b
+description: 'National disaster loss inventory for Niger from the DesInventar Sendai
+  Framework Monitor database, compiled by Systeme d''Alerte Precoce (SAP) and published
+  by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 1,364
+  event-level loss records covering 1990-2013, with observed impacts from drought,
+  flood, wildfire events. Loss data includes human casualties, displacement, building
+  damage, economic losses, agricultural damage, and infrastructure impacts. [Source:
+  This metadata record was automatically extracted from the Humanitarian Data Exchange
+  (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0]'
+details: 'Event-level disaster loss records from the DesInventar database for Niger,
+  maintained by Systeme d''Alerte Precoce (SAP). Covers 1,364 observed disaster events
+  from 1990-2013. Data collected through direct observational reporting and includes
+  human impacts (deaths, injuries, missing, affected, evacuated, relocated), physical
+  impacts (houses destroyed/damaged, education centres, hospitals, roads), economic
+  losses (local currency and USD), and agricultural impacts (crop damage in hectares,
+  livestock losses). Methodology: Direct Observational Data / Anecdotal Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from drought (DROUGHT)
+    events in Niger. DesInventar records: 2 events with data out of 289 total drought
+    events (1998-2005)., Observed deaths directly caused by disaster events from flood
+    (FLOOD) events in Niger. DesInventar records: 49 events with data out of 765 total
+    flood events (1990-2012)., Observed deaths directly caused by disaster events
+    from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 23 events
+    with data out of 310 total wildfire events (1992-2013)., Observed educational
+    facilities destroyed or affected from flood (FLOOD) events in Niger. DesInventar
+    records: 5 events with data out of 765 total flood events (1990-2012)., Observed
+    educational facilities destroyed or affected from wildfire (FIRE, FOREST FIRE)
+    events in Niger. DesInventar records: 2 events with data out of 310 total wildfire
+    events (1992-2013)., Observed health facilities destroyed or affected from flood
+    (FLOOD) events in Niger. DesInventar records: 1 events with data out of 765 total
+    flood events (1990-2012)., Observed hectares of crops/woods destroyed or affected
+    from drought (DROUGHT) events in Niger. DesInventar records: 15 events with data
+    out of 289 total drought events (1998-2005)., Observed hectares of crops/woods
+    destroyed or affected from flood (FLOOD) events in Niger. DesInventar records:
+    239 events with data out of 765 total flood events (1990-2012)., Observed hectares
+    of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events
+    in Niger. DesInventar records: 168 events with data out of 310 total wildfire
+    events (1992-2013)., Observed homes destroyed beyond habitability from flood (FLOOD)
+    events in Niger. DesInventar records: 412 events with data out of 765 total flood
+    events (1990-2012)., Observed homes destroyed beyond habitability from wildfire
+    (FIRE, FOREST FIRE) events in Niger. DesInventar records: 28 events with data
+    out of 310 total wildfire events (1992-2013)., Observed homes with non-structural
+    damage, still habitable from flood (FLOOD) events in Niger. DesInventar records:
+    29 events with data out of 765 total flood events (1990-2012)., Observed homes
+    with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE)
+    events in Niger. DesInventar records: 2 events with data out of 310 total wildfire
+    events (1992-2013)., Observed livestock lost from drought (DROUGHT) events in
+    Niger. DesInventar records: 14 events with data out of 289 total drought events
+    (1998-2005)., Observed livestock lost from flood (FLOOD) events in Niger. DesInventar
+    records: 122 events with data out of 765 total flood events (1990-2012)., Observed
+    livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
+    records: 14 events with data out of 310 total wildfire events (1992-2013)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from drought
+    (DROUGHT) events in Niger. DesInventar records: 46 events with data out of 289
+    total drought events (1998-2005)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from flood (FLOOD) events in Niger. DesInventar records:
+    216 events with data out of 765 total flood events (1990-2012)., Observed persons
+    indirectly affected (disruption to services, commerce, work) from wildfire (FIRE,
+    FOREST FIRE) events in Niger. DesInventar records: 78 events with data out of
+    310 total wildfire events (1992-2013)., Observed persons injured or made sick
+    directly by disaster events from flood (FLOOD) events in Niger. DesInventar records:
+    34 events with data out of 765 total flood events (1990-2012)., Observed persons
+    permanently relocated from homes from drought (DROUGHT) events in Niger. DesInventar
+    records: 10 events with data out of 289 total drought events (1998-2005)., Observed
+    persons permanently relocated from homes from flood (FLOOD) events in Niger. DesInventar
+    records: 2 events with data out of 765 total flood events (1990-2012)., Observed
+    persons whose goods/services suffered serious damage from drought (DROUGHT) events
+    in Niger. DesInventar records: 143 events with data out of 289 total drought events
+    (1998-2005)., Observed persons whose goods/services suffered serious damage from
+    flood (FLOOD) events in Niger. DesInventar records: 458 events with data out of
+    765 total flood events (1990-2012)., Observed persons whose goods/services suffered
+    serious damage from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
+    records: 48 events with data out of 310 total wildfire events (1992-2013)., Observed
+    total economic losses in US Dollars from flood (FLOOD) events in Niger. DesInventar
+    records: 1 events with data out of 765 total flood events (1990-2012)., Observed
+    total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in
+    Niger. DesInventar records: 2 events with data out of 310 total wildfire events
+    (1992-2013)., Observed total economic losses in local currency from drought (DROUGHT)
+    events in Niger. DesInventar records: 6 events with data out of 289 total drought
+    events (1998-2005)., Observed total economic losses in local currency from flood
+    (FLOOD) events in Niger. DesInventar records: 11 events with data out of 765 total
+    flood events (1990-2012)., Observed total economic losses in local currency from
+    wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 14 events with
+    data out of 310 total wildfire events (1992-2013).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: fluvial_flood, meteorological_drought, wildfire
+  hazard_type: drought, flood, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Niger from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Niger
+  download_url: https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0/resource/326e9447-51ce-4041-8f1a-dddadaa04275/download/niger.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Niger
+- coordinate_system: null
+  description: Disaster tabular data for Niger
+  download_url: https://data.humdata.org/dataset/60bb0852-2e19-4150-a142-34f7fc1e2fc0/resource/0f7c539d-baa5-403e-b049-01547f8bbd40/download/di_report-niger.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster tabular data for Niger
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-nerundrr_desinventar_b
+spatial:
+  bbox:
+  - 0.15
+  - 11.7
+  - 15.97
+  - 23.52
+  countries:
+  - NER
+  gazetteer_entries:
+  - description: Niger
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/2440476/niger.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Niger
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-senundrr_desinventar_a.md
+++ b/_datasets/rdls_lss-senundrr_desinventar_a.md
@@ -1,0 +1,173 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Direction de la Protection Civile (DPC)
+  url: https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-senundrr_desinventar_a
+description: 'National disaster loss inventory for Senegal from the DesInventar Sendai
+  Framework Monitor database, compiled by Direction de la Protection Civile (DPC)
+  and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 778 event-level loss records covering 1984-1992, with observed impacts
+  from drought, flood, strong_wind, wildfire events. Loss data includes human casualties,
+  displacement, building damage, economic losses, agricultural damage, and infrastructure
+  impacts. [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb]'
+details: 'Event-level disaster loss records from the DesInventar database for Senegal,
+  maintained by Direction de la Protection Civile (DPC). Covers 778 observed disaster
+  events from 1984-1992. Data collected through direct observational reporting and
+  includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from flood (FLOOD)
+    events in Senegal. DesInventar records: 22 events with data out of 149 total flood
+    events., Observed deaths directly caused by disaster events from strong wind (STORM)
+    events in Senegal. DesInventar records: 2 events with data out of 13 total strong
+    wind events., Observed deaths directly caused by disaster events from wildfire
+    (FIRE) events in Senegal. DesInventar records: 50 events with data out of 580
+    total wildfire events., Observed educational facilities destroyed or affected
+    from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data
+    out of 149 total flood events., Observed educational facilities destroyed or affected
+    from wildfire (FIRE) events in Senegal. DesInventar records: 17 events with data
+    out of 580 total wildfire events., Observed health facilities destroyed or affected
+    from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data
+    out of 149 total flood events., Observed health facilities destroyed or affected
+    from wildfire (FIRE) events in Senegal. DesInventar records: 3 events with data
+    out of 580 total wildfire events., Observed hectares of crops/woods destroyed
+    or affected from flood (FLOOD) events in Senegal. DesInventar records: 14 events
+    with data out of 149 total flood events., Observed hectares of crops/woods destroyed
+    or affected from wildfire (FIRE) events in Senegal. DesInventar records: 1 events
+    with data out of 580 total wildfire events., Observed homes destroyed beyond habitability
+    from flood (FLOOD) events in Senegal. DesInventar records: 8 events with data
+    out of 149 total flood events., Observed homes destroyed beyond habitability from
+    wildfire (FIRE) events in Senegal. DesInventar records: 16 events with data out
+    of 580 total wildfire events., Observed homes with non-structural damage, still
+    habitable from flood (FLOOD) events in Senegal. DesInventar records: 45 events
+    with data out of 149 total flood events., Observed homes with non-structural damage,
+    still habitable from wildfire (FIRE) events in Senegal. DesInventar records: 204
+    events with data out of 580 total wildfire events., Observed livestock lost from
+    wildfire (FIRE) events in Senegal. DesInventar records: 5 events with data out
+    of 580 total wildfire events., Observed persons indirectly affected (disruption
+    to services, commerce, work) from flood (FLOOD) events in Senegal. DesInventar
+    records: 18 events with data out of 149 total flood events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from wildfire (FIRE)
+    events in Senegal. DesInventar records: 4 events with data out of 580 total wildfire
+    events., Observed persons injured or made sick directly by disaster events from
+    flood (FLOOD) events in Senegal. DesInventar records: 12 events with data out
+    of 149 total flood events., Observed persons injured or made sick directly by
+    disaster events from wildfire (FIRE) events in Senegal. DesInventar records: 29
+    events with data out of 580 total wildfire events., Observed persons missing or
+    unaccounted for after disaster events from flood (FLOOD) events in Senegal. DesInventar
+    records: 4 events with data out of 149 total flood events., Observed persons missing
+    or unaccounted for after disaster events from strong wind (STORM) events in Senegal.
+    DesInventar records: 11 events with data out of 13 total strong wind events.,
+    Observed persons permanently relocated from homes from flood (FLOOD) events in
+    Senegal. DesInventar records: 3 events with data out of 149 total flood events.,
+    Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD)
+    events in Senegal. DesInventar records: 2 events with data out of 149 total flood
+    events., Observed persons temporarily evacuated from homes or workplaces from
+    strong wind (STORM) events in Senegal. DesInventar records: 7 events with data
+    out of 13 total strong wind events., Observed persons whose goods/services suffered
+    serious damage from flood (FLOOD) events in Senegal. DesInventar records: 16 events
+    with data out of 149 total flood events., Observed persons whose goods/services
+    suffered serious damage from wildfire (FIRE) events in Senegal. DesInventar records:
+    25 events with data out of 580 total wildfire events., Observed total economic
+    losses in US Dollars from flood (FLOOD) events in Senegal. DesInventar records:
+    2 events with data out of 149 total flood events., Observed total economic losses
+    in US Dollars from wildfire (FIRE) events in Senegal. DesInventar records: 59
+    events with data out of 580 total wildfire events., Observed total economic losses
+    in local currency from flood (FLOOD) events in Senegal. DesInventar records: 3
+    events with data out of 149 total flood events., Observed total economic losses
+    in local currency from wildfire (FIRE) events in Senegal. DesInventar records:
+    2 events with data out of 580 total wildfire events.'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, wildfire
+  hazard_type: flood, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Senegal from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate
+    change event
+  download_url: https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb/resource/a93d352d-bd3f-4161-a471-8f015b89679b/download/senegal.xlsx
+  format: Excel (xlsx)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims
+    Affected, Relocated, Evacuated, Losses and Damages in crops by climate change
+    event
+- coordinate_system: null
+  description: DesInventar disaster loss data for Senegal
+  download_url: https://data.humdata.org/dataset/dc29e362-55fc-458f-af09-477d3f0e2bcb/resource/688b6947-c44d-40bb-a9b0-46b4c5ae91d7/download/senegal.zip
+  format: Shapefile (shp)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Senegal.zip
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-senundrr_desinventar_a
+spatial:
+  bbox:
+  - -17.54
+  - 12.31
+  - -11.38
+  - 16.69
+  countries:
+  - SEN
+  gazetteer_entries:
+  - description: Senegal
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/2245662/senegal.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Senegal
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-senundrr_desinventar_b.md
+++ b/_datasets/rdls_lss-senundrr_desinventar_b.md
@@ -1,0 +1,173 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Direction de la Protection Civile (DPC)
+  url: https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-senundrr_desinventar_b
+description: 'National disaster loss inventory for Senegal from the DesInventar Sendai
+  Framework Monitor database, compiled by Direction de la Protection Civile (DPC)
+  and published by the United Nations Office for Disaster Risk Reduction (UNDRR).
+  Contains 778 event-level loss records covering 1984-2014, with observed impacts
+  from drought, flood, strong_wind, wildfire events. Loss data includes human casualties,
+  displacement, building damage, economic losses, agricultural damage, and infrastructure
+  impacts. [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a]'
+details: 'Event-level disaster loss records from the DesInventar database for Senegal,
+  maintained by Direction de la Protection Civile (DPC). Covers 778 observed disaster
+  events from 1984-2014. Data collected through direct observational reporting and
+  includes human impacts (deaths, injuries, missing, affected, evacuated, relocated),
+  physical impacts (houses destroyed/damaged, education centres, hospitals, roads),
+  economic losses (local currency and USD), and agricultural impacts (crop damage
+  in hectares, livestock losses). Methodology: Direct Observational Data / Anecdotal
+  Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from flood (FLOOD)
+    events in Senegal. DesInventar records: 22 events with data out of 149 total flood
+    events (2008-2010)., Observed deaths directly caused by disaster events from strong
+    wind (STORM) events in Senegal. DesInventar records: 2 events with data out of
+    13 total strong wind events (2013-2014)., Observed deaths directly caused by disaster
+    events from wildfire (FIRE) events in Senegal. DesInventar records: 50 events
+    with data out of 580 total wildfire events (2010-2014)., Observed educational
+    facilities destroyed or affected from flood (FLOOD) events in Senegal. DesInventar
+    records: 2 events with data out of 149 total flood events (2008-2010)., Observed
+    educational facilities destroyed or affected from wildfire (FIRE) events in Senegal.
+    DesInventar records: 17 events with data out of 580 total wildfire events (2010-2014).,
+    Observed health facilities destroyed or affected from flood (FLOOD) events in
+    Senegal. DesInventar records: 2 events with data out of 149 total flood events
+    (2008-2010)., Observed health facilities destroyed or affected from wildfire (FIRE)
+    events in Senegal. DesInventar records: 3 events with data out of 580 total wildfire
+    events (2010-2014)., Observed hectares of crops/woods destroyed or affected from
+    flood (FLOOD) events in Senegal. DesInventar records: 14 events with data out
+    of 149 total flood events (2008-2010)., Observed hectares of crops/woods destroyed
+    or affected from wildfire (FIRE) events in Senegal. DesInventar records: 1 events
+    with data out of 580 total wildfire events (2010-2014)., Observed homes destroyed
+    beyond habitability from flood (FLOOD) events in Senegal. DesInventar records:
+    8 events with data out of 149 total flood events (2008-2010)., Observed homes
+    destroyed beyond habitability from wildfire (FIRE) events in Senegal. DesInventar
+    records: 16 events with data out of 580 total wildfire events (2010-2014)., Observed
+    homes with non-structural damage, still habitable from flood (FLOOD) events in
+    Senegal. DesInventar records: 45 events with data out of 149 total flood events
+    (2008-2010)., Observed homes with non-structural damage, still habitable from
+    wildfire (FIRE) events in Senegal. DesInventar records: 204 events with data out
+    of 580 total wildfire events (2010-2014)., Observed livestock lost from wildfire
+    (FIRE) events in Senegal. DesInventar records: 5 events with data out of 580 total
+    wildfire events (2010-2014)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from flood (FLOOD) events in Senegal. DesInventar
+    records: 18 events with data out of 149 total flood events (2008-2010)., Observed
+    persons indirectly affected (disruption to services, commerce, work) from wildfire
+    (FIRE) events in Senegal. DesInventar records: 4 events with data out of 580 total
+    wildfire events (2010-2014)., Observed persons injured or made sick directly by
+    disaster events from flood (FLOOD) events in Senegal. DesInventar records: 12
+    events with data out of 149 total flood events (2008-2010)., Observed persons
+    injured or made sick directly by disaster events from wildfire (FIRE) events in
+    Senegal. DesInventar records: 29 events with data out of 580 total wildfire events
+    (2010-2014)., Observed persons missing or unaccounted for after disaster events
+    from flood (FLOOD) events in Senegal. DesInventar records: 4 events with data
+    out of 149 total flood events (2008-2010)., Observed persons missing or unaccounted
+    for after disaster events from strong wind (STORM) events in Senegal. DesInventar
+    records: 11 events with data out of 13 total strong wind events (2013-2014).,
+    Observed persons permanently relocated from homes from flood (FLOOD) events in
+    Senegal. DesInventar records: 3 events with data out of 149 total flood events
+    (2008-2010)., Observed persons temporarily evacuated from homes or workplaces
+    from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data
+    out of 149 total flood events (2008-2010)., Observed persons temporarily evacuated
+    from homes or workplaces from strong wind (STORM) events in Senegal. DesInventar
+    records: 7 events with data out of 13 total strong wind events (2013-2014)., Observed
+    persons whose goods/services suffered serious damage from flood (FLOOD) events
+    in Senegal. DesInventar records: 16 events with data out of 149 total flood events
+    (2008-2010)., Observed persons whose goods/services suffered serious damage from
+    wildfire (FIRE) events in Senegal. DesInventar records: 25 events with data out
+    of 580 total wildfire events (2010-2014)., Observed total economic losses in US
+    Dollars from flood (FLOOD) events in Senegal. DesInventar records: 2 events with
+    data out of 149 total flood events (2008-2010)., Observed total economic losses
+    in US Dollars from wildfire (FIRE) events in Senegal. DesInventar records: 59
+    events with data out of 580 total wildfire events (2010-2014)., Observed total
+    economic losses in local currency from flood (FLOOD) events in Senegal. DesInventar
+    records: 3 events with data out of 149 total flood events (2008-2010)., Observed
+    total economic losses in local currency from wildfire (FIRE) events in Senegal.
+    DesInventar records: 2 events with data out of 580 total wildfire events (2010-2014).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, wildfire
+  hazard_type: flood, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Senegal from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Disaster data for Senegal
+  download_url: https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a/resource/33a8ca9d-9c6a-429b-9e13-daf4588e4689/download/senegal.zip
+  format: Shapefile (shp)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster data for Senegal
+- coordinate_system: null
+  description: Disaster tabular data for Senegal
+  download_url: https://data.humdata.org/dataset/34f077f2-7270-45db-8f95-da5e4bfd5c9a/resource/7afd0d14-1561-4bd8-9d62-729fc2e6f6bf/download/di_report-senegal.xls
+  format: Excel (xlsx)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Disaster tabular data for Senegal
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-senundrr_desinventar_b
+spatial:
+  bbox:
+  - -17.54
+  - 12.31
+  - -11.38
+  - 16.69
+  countries:
+  - SEN
+  gazetteer_entries:
+  - description: Senegal
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/2245662/senegal.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Senegal
+version: '1'
+vulnerability: null
+---

--- a/_datasets/rdls_lss-tgoundrr_desinventar.md
+++ b/_datasets/rdls_lss-tgoundrr_desinventar.md
@@ -1,0 +1,228 @@
+---
+contact_point:
+  email: null
+  id: attribution_contact
+  name: Comite National de Secours
+  url: https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a
+creator:
+  email: isdr@un.org
+  id: attribution_creator
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.desinventar.net/
+dataset_id: rdls_lss-tgoundrr_desinventar
+description: 'National disaster loss inventory for Togo from the DesInventar Sendai
+  Framework Monitor database, compiled by Comite National de Secours and published
+  by the United Nations Office for Disaster Risk Reduction (UNDRR). Contains 391 event-level
+  loss records covering 1960-2013, with observed impacts from convective_storm, flood,
+  landslide, strong_wind, wildfire events. Loss data includes human casualties, displacement,
+  building damage, economic losses, agricultural damage, and infrastructure impacts.
+  [Source: This metadata record was automatically extracted from the Humanitarian
+  Data Exchange (HDX) at https://data.humdata.org] [Original dataset: https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a]'
+details: 'Event-level disaster loss records from the DesInventar database for Togo,
+  maintained by Comite National de Secours. Covers 391 observed disaster events from
+  1960-2013. Data collected through direct observational reporting and includes human
+  impacts (deaths, injuries, missing, affected, evacuated, relocated), physical impacts
+  (houses destroyed/damaged, education centres, hospitals, roads), economic losses
+  (local currency and USD), and agricultural impacts (crop damage in hectares, livestock
+  losses). Methodology: Direct Observational Data / Anecdotal Data.'
+exposure: []
+extra_attributions: []
+hazard: null
+license: CC-BY-4.0
+loss:
+  approach: ''
+  base_data_type: ''
+  category: ''
+  description: 'Observed deaths directly caused by disaster events from convective
+    storm (Thunderstorm) events in Togo. DesInventar records: 1 events with data out
+    of 9 total convective storm events (2011-2011)., Observed deaths directly caused
+    by disaster events from flood (Flood) events in Togo. DesInventar records: 32
+    events with data out of 135 total flood events., Observed deaths directly caused
+    by disaster events from landslide (Landslide) events in Togo. DesInventar records:
+    1 events with data out of 6 total landslide events., Observed deaths directly
+    caused by disaster events from strong wind (Hurricane) events in Togo. DesInventar
+    records: 1 events with data out of 40 total strong wind events (1960-2013)., Observed
+    deaths directly caused by disaster events from wildfire (Fire, Forest fire) events
+    in Togo. DesInventar records: 13 events with data out of 197 total wildfire events
+    (2009-2009)., Observed educational facilities destroyed or affected from convective
+    storm (Thunderstorm) events in Togo. DesInventar records: 6 events with data out
+    of 9 total convective storm events (2011-2011)., Observed educational facilities
+    destroyed or affected from flood (Flood) events in Togo. DesInventar records:
+    15 events with data out of 135 total flood events., Observed educational facilities
+    destroyed or affected from strong wind (Hurricane) events in Togo. DesInventar
+    records: 14 events with data out of 40 total strong wind events (1960-2013).,
+    Observed educational facilities destroyed or affected from strong wind (Storm)
+    events in Togo. DesInventar records: 1 events with data out of 4 total strong
+    wind events., Observed educational facilities destroyed or affected from wildfire
+    (Fire, Forest fire) events in Togo. DesInventar records: 9 events with data out
+    of 197 total wildfire events (2009-2009)., Observed health facilities destroyed
+    or affected from flood (Flood) events in Togo. DesInventar records: 2 events with
+    data out of 135 total flood events., Observed health facilities destroyed or affected
+    from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with
+    data out of 40 total strong wind events (1960-2013)., Observed hectares of crops/woods
+    destroyed or affected from flood (Flood) events in Togo. DesInventar records:
+    21 events with data out of 135 total flood events., Observed hectares of crops/woods
+    destroyed or affected from wildfire (Fire, Forest fire) events in Togo. DesInventar
+    records: 14 events with data out of 197 total wildfire events (2009-2009)., Observed
+    homes destroyed beyond habitability from convective storm (Thunderstorm) events
+    in Togo. DesInventar records: 2 events with data out of 9 total convective storm
+    events (2011-2011)., Observed homes destroyed beyond habitability from flood (Flood)
+    events in Togo. DesInventar records: 59 events with data out of 135 total flood
+    events., Observed homes destroyed beyond habitability from landslide (Landslide)
+    events in Togo. DesInventar records: 5 events with data out of 6 total landslide
+    events., Observed homes destroyed beyond habitability from strong wind (Hurricane)
+    events in Togo. DesInventar records: 5 events with data out of 40 total strong
+    wind events (1960-2013)., Observed homes destroyed beyond habitability from wildfire
+    (Fire, Forest fire) events in Togo. DesInventar records: 64 events with data out
+    of 197 total wildfire events (2009-2009)., Observed homes with non-structural
+    damage, still habitable from convective storm (Thunderstorm) events in Togo. DesInventar
+    records: 4 events with data out of 9 total convective storm events (2011-2011).,
+    Observed homes with non-structural damage, still habitable from flood (Flood)
+    events in Togo. DesInventar records: 54 events with data out of 135 total flood
+    events., Observed homes with non-structural damage, still habitable from landslide
+    (Landslide) events in Togo. DesInventar records: 5 events with data out of 6 total
+    landslide events., Observed homes with non-structural damage, still habitable
+    from strong wind (Hurricane) events in Togo. DesInventar records: 14 events with
+    data out of 40 total strong wind events (1960-2013)., Observed homes with non-structural
+    damage, still habitable from strong wind (Storm) events in Togo. DesInventar records:
+    1 events with data out of 4 total strong wind events., Observed homes with non-structural
+    damage, still habitable from wildfire (Fire, Forest fire) events in Togo. DesInventar
+    records: 50 events with data out of 197 total wildfire events (2009-2009)., Observed
+    livestock lost from flood (Flood) events in Togo. DesInventar records: 1 events
+    with data out of 135 total flood events., Observed livestock lost from strong
+    wind (Hurricane) events in Togo. DesInventar records: 1 events with data out of
+    40 total strong wind events (1960-2013)., Observed metres of transport networks
+    destroyed from flood (Flood) events in Togo. DesInventar records: 4 events with
+    data out of 135 total flood events., Observed persons indirectly affected (disruption
+    to services, commerce, work) from convective storm (Thunderstorm) events in Togo.
+    DesInventar records: 2 events with data out of 9 total convective storm events
+    (2011-2011)., Observed persons indirectly affected (disruption to services, commerce,
+    work) from flood (Flood) events in Togo. DesInventar records: 109 events with
+    data out of 135 total flood events., Observed persons indirectly affected (disruption
+    to services, commerce, work) from landslide (Landslide) events in Togo. DesInventar
+    records: 5 events with data out of 6 total landslide events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from strong wind
+    (Hurricane) events in Togo. DesInventar records: 20 events with data out of 40
+    total strong wind events (1960-2013)., Observed persons indirectly affected (disruption
+    to services, commerce, work) from strong wind (Storm) events in Togo. DesInventar
+    records: 4 events with data out of 4 total strong wind events., Observed persons
+    indirectly affected (disruption to services, commerce, work) from wildfire (Fire,
+    Forest fire) events in Togo. DesInventar records: 162 events with data out of
+    197 total wildfire events (2009-2009)., Observed persons injured or made sick
+    directly by disaster events from flood (Flood) events in Togo. DesInventar records:
+    22 events with data out of 135 total flood events., Observed persons injured or
+    made sick directly by disaster events from strong wind (Hurricane) events in Togo.
+    DesInventar records: 3 events with data out of 40 total strong wind events (1960-2013).,
+    Observed persons injured or made sick directly by disaster events from wildfire
+    (Fire, Forest fire) events in Togo. DesInventar records: 7 events with data out
+    of 197 total wildfire events (2009-2009)., Observed persons missing or unaccounted
+    for after disaster events from flood (Flood) events in Togo. DesInventar records:
+    2 events with data out of 135 total flood events., Observed persons permanently
+    relocated from homes from flood (Flood) events in Togo. DesInventar records: 32
+    events with data out of 135 total flood events., Observed persons permanently
+    relocated from homes from wildfire (Fire, Forest fire) events in Togo. DesInventar
+    records: 12 events with data out of 197 total wildfire events (2009-2009)., Observed
+    persons temporarily evacuated from homes or workplaces from flood (Flood) events
+    in Togo. DesInventar records: 11 events with data out of 135 total flood events.,
+    Observed persons temporarily evacuated from homes or workplaces from landslide
+    (Landslide) events in Togo. DesInventar records: 1 events with data out of 6 total
+    landslide events., Observed persons temporarily evacuated from homes or workplaces
+    from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with
+    data out of 40 total strong wind events (1960-2013)., Observed persons temporarily
+    evacuated from homes or workplaces from wildfire (Fire, Forest fire) events in
+    Togo. DesInventar records: 4 events with data out of 197 total wildfire events
+    (2009-2009)., Observed persons whose goods/services suffered serious damage from
+    flood (Flood) events in Togo. DesInventar records: 16 events with data out of
+    135 total flood events., Observed persons whose goods/services suffered serious
+    damage from landslide (Landslide) events in Togo. DesInventar records: 5 events
+    with data out of 6 total landslide events., Observed persons whose goods/services
+    suffered serious damage from wildfire (Fire, Forest fire) events in Togo. DesInventar
+    records: 10 events with data out of 197 total wildfire events (2009-2009)., Observed
+    total economic losses in US Dollars from convective storm (Thunderstorm) events
+    in Togo. DesInventar records: 1 events with data out of 9 total convective storm
+    events (2011-2011)., Observed total economic losses in US Dollars from flood (Flood)
+    events in Togo. DesInventar records: 30 events with data out of 135 total flood
+    events., Observed total economic losses in US Dollars from strong wind (Hurricane)
+    events in Togo. DesInventar records: 7 events with data out of 40 total strong
+    wind events (1960-2013)., Observed total economic losses in US Dollars from strong
+    wind (Storm) events in Togo. DesInventar records: 2 events with data out of 4
+    total strong wind events., Observed total economic losses in US Dollars from wildfire
+    (Fire, Forest fire) events in Togo. DesInventar records: 74 events with data out
+    of 197 total wildfire events (2009-2009).'
+  dimension: ''
+  exposure_id: ''
+  hazard_analysis_type: ''
+  hazard_id: ''
+  hazard_process: extratropical_cyclone, fluvial_flood, landslide_general, tornado,
+    tropical_cyclone, wildfire
+  hazard_type: convective_storm, flood, landslide, strong_wind, wildfire
+  impact_metric: ''
+  impact_type: ''
+  impact_unit: ''
+  type: ''
+  vulnerability_id: ''
+project:
+  name: DesInventar Sendai - Disaster Information Management System
+  url: https://www.desinventar.net/
+publisher:
+  email: isdr@un.org
+  id: attribution_publisher
+  name: United Nations Office for Disaster Risk Reduction (UNDRR)
+  url: https://www.undrr.org/
+purpose: To document historical disaster losses in Togo from the DesInventar national
+  disaster loss inventory, supporting disaster risk reduction monitoring under the
+  Sendai Framework.
+resources:
+- coordinate_system: null
+  description: Dataset-level metadata exported from HDX.
+  download_url: https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a/download_metadata?format=json
+  format: JSON (json)
+  id: hdx_dataset_metadata_json
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: HDX dataset metadata (JSON)
+- coordinate_system: null
+  description: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged,
+    Victims Affected, Relocated, Evacuated, Losses and Damages in crops by climate
+    change event
+  download_url: https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a/resource/2d0ac135-1e71-4d2d-a2b5-e025406a5c08/download/togo.xlsx
+  format: Excel (xlsx)
+  id: resource_001
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Number of Deaths, Injured, Missing, Houses Destroyed, Houses Damaged, Victims
+    Affected, Relocated, Evacuated, Losses and Damages in crops by climate change
+    event
+- coordinate_system: null
+  description: DesInventar disaster loss data for Togo
+  download_url: https://data.humdata.org/dataset/463af9ac-a311-4d10-9ab9-cdb0ef4ed22a/resource/d6b85b8c-0b19-45e8-a6d8-9133b33c9be0/download/togo.zip
+  format: Shapefile (shp)
+  id: resource_002
+  media_type: null
+  spatial_resolution: null
+  temporal: null
+  title: Togo.zip
+risk_data_type:
+- loss
+schema: rdl-03
+slug: rdls_lss-tgoundrr_desinventar
+spatial:
+  bbox:
+  - -0.17
+  - 6.1
+  - 1.78
+  - 11.13
+  countries:
+  - TGO
+  gazetteer_entries:
+  - description: Togo
+    id: gazetteer_1
+    scheme: GEONAMES
+    uri: https://www.geonames.org/2363686/togo.html
+  scale: national
+title: DesInventar Disaster Loss and Damage Dataset for Togo
+version: '1'
+vulnerability: null
+---


### PR DESCRIPTION
This PR contains 16 json metadata from DesInventar. Originally this data was skipped on first iteration due to the signal type `general_loss`, and the original HDX metadata doesn't name a specific hazard type (flood, earthquake, etc.).

It's a multi-hazard loss inventory, while the pipeline requires an explicit `hazard_type` match.

https://github.com/GFDRR/rdl-standard/issues/371#issuecomment-3915066342