### PR TITLE
Fix catalog filter

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -218,9 +218,10 @@
               // Catalog filter
               if (excludeFilterType !== 'catalog' && this.filters.catalog.length > 0) {
                 const datasetCatalogs = Array.isArray(dataset.catalog) ? dataset.catalog : [dataset.catalog];
-                const hasMatchingCatalog = datasetCatalogs.some(cat =>
-                  this.filters.catalog.includes(slugify(cat))
-                );
+                const hasMatchingCatalog = datasetCatalogs.some(cat => {
+                  if (cat === null || cat === undefined) return false;
+                  return this.filters.catalog.includes(slugify(cat))
+                });
                 if (!hasMatchingCatalog) return false;
               }
 


### PR DESCRIPTION
@matamadio I'm just merging this to quickly resolve the error you mentioned in your email.

Basically, we sometimes have undefined catalogs for when none is found, and they were getting passed to a function that expects a string.