### PR TITLE
Revision DesInventar metadata description and proposal loss group

### DIFF
--- a/_data/schemas/rdl-02.yml
+++ b/_data/schemas/rdl-02.yml
@@ -322,6 +322,11 @@ loss:
     display_template: display/process_type.html
   - field_name: description
     label: Description
+  - field_name: loss_count
+    label: Total Loss Records
+  - field_name: loss_groups
+    label: Loss Records Detail
+    display_template: display/loss_groups.html
   - field_name: category
     label: Category
     display_template: display/exposure_category.html

--- a/_data/schemas/rdl-02.yml
+++ b/_data/schemas/rdl-02.yml
@@ -322,11 +322,6 @@ loss:
     display_template: display/process_type.html
   - field_name: description
     label: Description
-  - field_name: loss_count
-    label: Total Loss Records
-  - field_name: loss_groups
-    label: Loss Records Detail
-    display_template: display/loss_groups.html
   - field_name: category
     label: Category
     display_template: display/exposure_category.html

--- a/_data/schemas/rdl-03.yml
+++ b/_data/schemas/rdl-03.yml
@@ -322,6 +322,11 @@ loss:
     display_template: display/process_type.html
   - field_name: description
     label: Description
+  - field_name: loss_count
+    label: Total Loss Records
+  - field_name: loss_groups
+    label: Loss Records Detail
+    display_template: display/loss_groups.html
   - field_name: category
     label: Category
     display_template: display/exposure_category.html

--- a/_data/schemas/rdl-03.yml
+++ b/_data/schemas/rdl-03.yml
@@ -322,11 +322,6 @@ loss:
     display_template: display/process_type.html
   - field_name: description
     label: Description
-  - field_name: loss_count
-    label: Total Loss Records
-  - field_name: loss_groups
-    label: Loss Records Detail
-    display_template: display/loss_groups.html
   - field_name: category
     label: Category
     display_template: display/exposure_category.html

--- a/_datasets/rdls_hzd-hdx_hdx_ton_ton_ibtracs_tropical_storm_tracks_windstorm.md
+++ b/_datasets/rdls_hzd-hdx_hdx_ton_ton_ibtracs_tropical_storm_tracks_windstorm.md
@@ -46,7 +46,7 @@ hazard:
   occurrence_range: ''
   processes: tornado
   seasonality: ''
-license: CC-BY-IGO-3.0
+license: Creative Commons Attribution for Intergovernmental Organisations (CC BY-IGO)
 loss: null
 project: null
 publisher:

--- a/_datasets/rdls_lss-albundrr_desinventar.md
+++ b/_datasets/rdls_lss-albundrr_desinventar.md
@@ -36,272 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from convective
-    storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 54 events
-    with data out of 217 total convective storm events (1976-2014)., Observed deaths
-    directly caused by disaster events from earthquake (EARTHQUAKE) events in Albania.
-    DesInventar records: 14 events with data out of 185 total earthquake events (2014-2014).,
-    Observed deaths directly caused by disaster events from extreme temperature (COLD
-    WAVE, FROST) events in Albania. DesInventar records: 10 events with data out of
-    126 total extreme temperature events (1990-2012)., Observed deaths directly caused
-    by disaster events from extreme temperature (HEAT WAVE) events in Albania. DesInventar
-    records: 9 events with data out of 22 total extreme temperature events (1998-2002).,
-    Observed deaths directly caused by disaster events from flood (FLASH FLOOD, FLOOD)
-    events in Albania. DesInventar records: 44 events with data out of 949 total flood
-    events (2002-2015)., Observed deaths directly caused by disaster events from flood
-    (RAINS) events in Albania. DesInventar records: 3 events with data out of 217
-    total flood events (2007-2013)., Observed deaths directly caused by disaster events
-    from landslide (AVALANCHE) events in Albania. DesInventar records: 17 events with
-    data out of 25 total landslide events (2010-2012)., Observed deaths directly caused
-    by disaster events from landslide (LANDSLIDE) events in Albania. DesInventar records:
-    40 events with data out of 629 total landslide events (1995-2013)., Observed deaths
-    directly caused by disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM)
-    events in Albania. DesInventar records: 45 events with data out of 891 total strong
-    wind events (1973-2012)., Observed deaths directly caused by disaster events from
-    wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 13 events
-    with data out of 1,383 total wildfire events (2003-2014)., Observed educational
-    facilities destroyed or affected from earthquake (EARTHQUAKE) events in Albania.
-    DesInventar records: 8 events with data out of 185 total earthquake events (2014-2014).,
-    Observed educational facilities destroyed or affected from flood (FLASH FLOOD,
-    FLOOD) events in Albania. DesInventar records: 13 events with data out of 949
-    total flood events (2002-2015)., Observed educational facilities destroyed or
-    affected from flood (RAINS) events in Albania. DesInventar records: 2 events with
-    data out of 217 total flood events (2007-2013)., Observed educational facilities
-    destroyed or affected from landslide (LANDSLIDE) events in Albania. DesInventar
-    records: 7 events with data out of 629 total landslide events (1995-2013)., Observed
-    educational facilities destroyed or affected from strong wind (SNOWSTORM, STORM,
-    WINDSTORM) events in Albania. DesInventar records: 28 events with data out of
-    891 total strong wind events (1973-2012)., Observed educational facilities destroyed
-    or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records:
-    1 events with data out of 1,383 total wildfire events (2003-2014)., Observed health
-    facilities destroyed or affected from earthquake (EARTHQUAKE) events in Albania.
-    DesInventar records: 5 events with data out of 185 total earthquake events (2014-2014).,
-    Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD)
-    events in Albania. DesInventar records: 2 events with data out of 949 total flood
-    events (2002-2015)., Observed health facilities destroyed or affected from strong
-    wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 1 events
-    with data out of 891 total strong wind events (1973-2012)., Observed health facilities
-    destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar
-    records: 1 events with data out of 1,383 total wildfire events (2003-2014)., Observed
-    hectares of crops/woods destroyed or affected from convective storm (HAILSTORM,
-    THUNDERSTORM) events in Albania. DesInventar records: 79 events with data out
-    of 217 total convective storm events (1976-2014)., Observed hectares of crops/woods
-    destroyed or affected from drought (DROUGHT) events in Albania. DesInventar records:
-    1 events with data out of 1 total drought events (1993-1993)., Observed hectares
-    of crops/woods destroyed or affected from extreme temperature (COLD WAVE, FROST)
-    events in Albania. DesInventar records: 55 events with data out of 126 total extreme
-    temperature events (1990-2012)., Observed hectares of crops/woods destroyed or
-    affected from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records:
-    474 events with data out of 949 total flood events (2002-2015)., Observed hectares
-    of crops/woods destroyed or affected from flood (RAINS) events in Albania. DesInventar
-    records: 49 events with data out of 217 total flood events (2007-2013)., Observed
-    hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events
-    in Albania. DesInventar records: 17 events with data out of 629 total landslide
-    events (1995-2013)., Observed hectares of crops/woods destroyed or affected from
-    landslide (SEDIMENTATION) events in Albania. DesInventar records: 2 events with
-    data out of 3 total landslide events (1999-2005)., Observed hectares of crops/woods
-    destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in
-    Albania. DesInventar records: 50 events with data out of 891 total strong wind
-    events (1973-2012)., Observed hectares of crops/woods destroyed or affected from
-    wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 716 events
-    with data out of 1,383 total wildfire events (2003-2014)., Observed homes destroyed
-    beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in
-    Albania. DesInventar records: 2 events with data out of 217 total convective storm
-    events (1976-2014)., Observed homes destroyed beyond habitability from earthquake
-    (EARTHQUAKE) events in Albania. DesInventar records: 66 events with data out of
-    185 total earthquake events (2014-2014)., Observed homes destroyed beyond habitability
-    from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 96 events
-    with data out of 949 total flood events (2002-2015)., Observed homes destroyed
-    beyond habitability from flood (RAINS) events in Albania. DesInventar records:
-    43 events with data out of 217 total flood events (2007-2013)., Observed homes
-    destroyed beyond habitability from landslide (AVALANCHE) events in Albania. DesInventar
-    records: 3 events with data out of 25 total landslide events (2010-2012)., Observed
-    homes destroyed beyond habitability from landslide (LANDSLIDE) events in Albania.
-    DesInventar records: 346 events with data out of 629 total landslide events (1995-2013).,
-    Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM,
-    WINDSTORM) events in Albania. DesInventar records: 108 events with data out of
-    891 total strong wind events (1973-2012)., Observed homes destroyed beyond habitability
-    from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 46 events
-    with data out of 1,383 total wildfire events (2003-2014)., Observed homes with
-    non-structural damage, still habitable from coastal flood (SURGE) events in Albania.
-    DesInventar records: 2 events with data out of 7 total coastal flood events (1975-2012).,
-    Observed homes with non-structural damage, still habitable from convective storm
-    (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 2 events with
-    data out of 217 total convective storm events (1976-2014)., Observed homes with
-    non-structural damage, still habitable from earthquake (EARTHQUAKE) events in
-    Albania. DesInventar records: 92 events with data out of 185 total earthquake
-    events (2014-2014)., Observed homes with non-structural damage, still habitable
-    from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar records:
-    2 events with data out of 126 total extreme temperature events (1990-2012)., Observed
-    homes with non-structural damage, still habitable from flood (FLASH FLOOD, FLOOD)
-    events in Albania. DesInventar records: 208 events with data out of 949 total
-    flood events (2002-2015)., Observed homes with non-structural damage, still habitable
-    from flood (RAINS) events in Albania. DesInventar records: 40 events with data
-    out of 217 total flood events (2007-2013)., Observed homes with non-structural
-    damage, still habitable from landslide (AVALANCHE) events in Albania. DesInventar
-    records: 3 events with data out of 25 total landslide events (2010-2012)., Observed
-    homes with non-structural damage, still habitable from landslide (LANDSLIDE) events
-    in Albania. DesInventar records: 117 events with data out of 629 total landslide
-    events (1995-2013)., Observed homes with non-structural damage, still habitable
-    from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
-    records: 86 events with data out of 891 total strong wind events (1973-2012).,
-    Observed homes with non-structural damage, still habitable from wildfire (FIRE,
-    FOREST FIRE) events in Albania. DesInventar records: 60 events with data out of
-    1,383 total wildfire events (2003-2014)., Observed livestock lost from convective
-    storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 18 events
-    with data out of 217 total convective storm events (1976-2014)., Observed livestock
-    lost from extreme temperature (COLD WAVE, FROST) events in Albania. DesInventar
-    records: 10 events with data out of 126 total extreme temperature events (1990-2012).,
-    Observed livestock lost from extreme temperature (HEAT WAVE) events in Albania.
-    DesInventar records: 1 events with data out of 22 total extreme temperature events
-    (1998-2002)., Observed livestock lost from flood (FLASH FLOOD, FLOOD) events in
-    Albania. DesInventar records: 96 events with data out of 949 total flood events
-    (2002-2015)., Observed livestock lost from flood (RAINS) events in Albania. DesInventar
-    records: 3 events with data out of 217 total flood events (2007-2013)., Observed
-    livestock lost from landslide (AVALANCHE) events in Albania. DesInventar records:
-    3 events with data out of 25 total landslide events (2010-2012)., Observed livestock
-    lost from landslide (LANDSLIDE) events in Albania. DesInventar records: 3 events
-    with data out of 629 total landslide events (1995-2013)., Observed livestock lost
-    from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
-    records: 65 events with data out of 891 total strong wind events (1973-2012).,
-    Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar
-    records: 11 events with data out of 1,383 total wildfire events (2003-2014).,
-    Observed metres of transport networks destroyed from earthquake (EARTHQUAKE) events
-    in Albania. DesInventar records: 1 events with data out of 185 total earthquake
-    events (2014-2014)., Observed metres of transport networks destroyed from flood
-    (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 19 events with data
-    out of 949 total flood events (2002-2015)., Observed metres of transport networks
-    destroyed from flood (RAINS) events in Albania. DesInventar records: 4 events
-    with data out of 217 total flood events (2007-2013)., Observed metres of transport
-    networks destroyed from landslide (LANDSLIDE) events in Albania. DesInventar records:
-    30 events with data out of 629 total landslide events (1995-2013)., Observed metres
-    of transport networks destroyed from strong wind (SNOWSTORM, STORM, WINDSTORM)
-    events in Albania. DesInventar records: 4 events with data out of 891 total strong
-    wind events (1973-2012)., Observed persons indirectly affected (disruption to
-    services, commerce, work) from earthquake (EARTHQUAKE) events in Albania. DesInventar
-    records: 8 events with data out of 185 total earthquake events (2014-2014)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from flood
-    (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 18 events with data
-    out of 949 total flood events (2002-2015)., Observed persons indirectly affected
-    (disruption to services, commerce, work) from flood (RAINS) events in Albania.
-    DesInventar records: 1 events with data out of 217 total flood events (2007-2013).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from landslide (LANDSLIDE) events in Albania. DesInventar records: 5 events with
-    data out of 629 total landslide events (1995-2013)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from strong wind (SNOWSTORM,
-    STORM, WINDSTORM) events in Albania. DesInventar records: 55 events with data
-    out of 891 total strong wind events (1973-2012)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from wildfire (FIRE, FOREST
-    FIRE) events in Albania. DesInventar records: 4 events with data out of 1,383
-    total wildfire events (2003-2014)., Observed persons injured or made sick directly
-    by disaster events from convective storm (HAILSTORM, THUNDERSTORM) events in Albania.
-    DesInventar records: 19 events with data out of 217 total convective storm events
-    (1976-2014)., Observed persons injured or made sick directly by disaster events
-    from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 18 events
-    with data out of 185 total earthquake events (2014-2014)., Observed persons injured
-    or made sick directly by disaster events from extreme temperature (COLD WAVE,
-    FROST) events in Albania. DesInventar records: 10 events with data out of 126
-    total extreme temperature events (1990-2012)., Observed persons injured or made
-    sick directly by disaster events from extreme temperature (HEAT WAVE) events in
-    Albania. DesInventar records: 11 events with data out of 22 total extreme temperature
-    events (1998-2002)., Observed persons injured or made sick directly by disaster
-    events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records:
-    18 events with data out of 949 total flood events (2002-2015)., Observed persons
-    injured or made sick directly by disaster events from flood (RAINS) events in
-    Albania. DesInventar records: 2 events with data out of 217 total flood events
-    (2007-2013)., Observed persons injured or made sick directly by disaster events
-    from landslide (AVALANCHE) events in Albania. DesInventar records: 8 events with
-    data out of 25 total landslide events (2010-2012)., Observed persons injured or
-    made sick directly by disaster events from landslide (LANDSLIDE) events in Albania.
-    DesInventar records: 15 events with data out of 629 total landslide events (1995-2013).,
-    Observed persons injured or made sick directly by disaster events from strong
-    wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 26
-    events with data out of 891 total strong wind events (1973-2012)., Observed persons
-    injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE)
-    events in Albania. DesInventar records: 6 events with data out of 1,383 total
-    wildfire events (2003-2014)., Observed persons missing or unaccounted for after
-    disaster events from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar
-    records: 1 events with data out of 949 total flood events (2002-2015)., Observed
-    persons missing or unaccounted for after disaster events from flood (RAINS) events
-    in Albania. DesInventar records: 1 events with data out of 217 total flood events
-    (2007-2013)., Observed persons missing or unaccounted for after disaster events
-    from landslide (AVALANCHE) events in Albania. DesInventar records: 2 events with
-    data out of 25 total landslide events (2010-2012)., Observed persons missing or
-    unaccounted for after disaster events from strong wind (SNOWSTORM, STORM, WINDSTORM)
-    events in Albania. DesInventar records: 4 events with data out of 891 total strong
-    wind events (1973-2012)., Observed persons permanently relocated from homes from
-    flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 4 events with
-    data out of 949 total flood events (2002-2015)., Observed persons permanently
-    relocated from homes from landslide (LANDSLIDE) events in Albania. DesInventar
-    records: 5 events with data out of 629 total landslide events (1995-2013)., Observed
-    persons permanently relocated from homes from wildfire (FIRE, FOREST FIRE) events
-    in Albania. DesInventar records: 5 events with data out of 1,383 total wildfire
-    events (2003-2014)., Observed persons temporarily evacuated from homes or workplaces
-    from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 5 events
-    with data out of 185 total earthquake events (2014-2014)., Observed persons temporarily
-    evacuated from homes or workplaces from flood (FLASH FLOOD, FLOOD) events in Albania.
-    DesInventar records: 76 events with data out of 949 total flood events (2002-2015).,
-    Observed persons temporarily evacuated from homes or workplaces from flood (RAINS)
-    events in Albania. DesInventar records: 2 events with data out of 217 total flood
-    events (2007-2013)., Observed persons temporarily evacuated from homes or workplaces
-    from landslide (LANDSLIDE) events in Albania. DesInventar records: 29 events with
-    data out of 629 total landslide events (1995-2013)., Observed persons temporarily
-    evacuated from homes or workplaces from strong wind (SNOWSTORM, STORM, WINDSTORM)
-    events in Albania. DesInventar records: 16 events with data out of 891 total strong
-    wind events (1973-2012)., Observed persons temporarily evacuated from homes or
-    workplaces from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records:
-    5 events with data out of 1,383 total wildfire events (2003-2014)., Observed persons
-    whose goods/services suffered serious damage from convective storm (HAILSTORM,
-    THUNDERSTORM) events in Albania. DesInventar records: 1 events with data out of
-    217 total convective storm events (1976-2014)., Observed persons whose goods/services
-    suffered serious damage from earthquake (EARTHQUAKE) events in Albania. DesInventar
-    records: 26 events with data out of 185 total earthquake events (2014-2014).,
-    Observed persons whose goods/services suffered serious damage from earthquake
-    (LIQUEFACTION) events in Albania. DesInventar records: 2 events with data out
-    of 4 total earthquake events (2014-2014)., Observed persons whose goods/services
-    suffered serious damage from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar
-    records: 129 events with data out of 949 total flood events (2002-2015)., Observed
-    persons whose goods/services suffered serious damage from flood (RAINS) events
-    in Albania. DesInventar records: 42 events with data out of 217 total flood events
-    (2007-2013)., Observed persons whose goods/services suffered serious damage from
-    landslide (AVALANCHE) events in Albania. DesInventar records: 1 events with data
-    out of 25 total landslide events (2010-2012)., Observed persons whose goods/services
-    suffered serious damage from landslide (LANDSLIDE) events in Albania. DesInventar
-    records: 249 events with data out of 629 total landslide events (1995-2013).,
-    Observed persons whose goods/services suffered serious damage from strong wind
-    (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 88 events
-    with data out of 891 total strong wind events (1973-2012)., Observed persons whose
-    goods/services suffered serious damage from wildfire (FIRE, FOREST FIRE) events
-    in Albania. DesInventar records: 37 events with data out of 1,383 total wildfire
-    events (2003-2014)., Observed total economic losses in US Dollars from flood (FLASH
-    FLOOD, FLOOD) events in Albania. DesInventar records: 4 events with data out of
-    949 total flood events (2002-2015)., Observed total economic losses in US Dollars
-    from landslide (LANDSLIDE) events in Albania. DesInventar records: 1 events with
-    data out of 629 total landslide events (1995-2013)., Observed total economic losses
-    in US Dollars from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar
-    records: 23 events with data out of 1,383 total wildfire events (2003-2014).,
-    Observed total economic losses in local currency from convective storm (HAILSTORM,
-    THUNDERSTORM) events in Albania. DesInventar records: 20 events with data out
-    of 217 total convective storm events (1976-2014)., Observed total economic losses
-    in local currency from earthquake (EARTHQUAKE) events in Albania. DesInventar
-    records: 78 events with data out of 185 total earthquake events (2014-2014).,
-    Observed total economic losses in local currency from extreme temperature (COLD
-    WAVE, FROST) events in Albania. DesInventar records: 5 events with data out of
-    126 total extreme temperature events (1990-2012)., Observed total economic losses
-    in local currency from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar
-    records: 225 events with data out of 949 total flood events (2002-2015)., Observed
-    total economic losses in local currency from flood (RAINS) events in Albania.
-    DesInventar records: 57 events with data out of 217 total flood events (2007-2013).,
-    Observed total economic losses in local currency from landslide (AVALANCHE) events
-    in Albania. DesInventar records: 2 events with data out of 25 total landslide
-    events (2010-2012)., Observed total economic losses in local currency from landslide
-    (LANDSLIDE) events in Albania. DesInventar records: 306 events with data out of
-    629 total landslide events (1995-2013)., Observed total economic losses in local
-    currency from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
-    records: 130 events with data out of 891 total strong wind events (1973-2012).,
-    Observed total economic losses in local currency from wildfire (FIRE, FOREST FIRE)
-    events in Albania. DesInventar records: 65 events with data out of 1,383 total
-    wildfire events (2003-2014).'
+  description: 111 loss records across 9 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -314,6 +49,363 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 111
+  loss_groups:
+  - count: 1
+    descriptions:
+    - 'Observed homes with non-structural damage, still habitable from coastal flood
+      (SURGE) events in Albania. DesInventar records: 2 events with data out of 7
+      total coastal flood events (1975-2012).'
+    hazard_type: coastal_flood
+  - count: 8
+    descriptions:
+    - 'Observed hectares of crops/woods destroyed or affected from convective storm
+      (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 79 events
+      with data out of 217 total convective storm events (1976-2014).'
+    - 'Observed deaths directly caused by disaster events from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Albania. DesInventar records: 54 events with data out
+      of 217 total convective storm events (1976-2014).'
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 2 events
+      with data out of 217 total convective storm events (1976-2014).'
+    - 'Observed homes destroyed beyond habitability from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Albania. DesInventar records: 2 events with data out
+      of 217 total convective storm events (1976-2014).'
+    - 'Observed persons injured or made sick directly by disaster events from convective
+      storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 19 events
+      with data out of 217 total convective storm events (1976-2014).'
+    - 'Observed total economic losses in local currency from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Albania. DesInventar records: 20 events with data out
+      of 217 total convective storm events (1976-2014).'
+    - 'Observed livestock lost from convective storm (HAILSTORM, THUNDERSTORM) events
+      in Albania. DesInventar records: 18 events with data out of 217 total convective
+      storm events (1976-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from convective
+      storm (HAILSTORM, THUNDERSTORM) events in Albania. DesInventar records: 1 events
+      with data out of 217 total convective storm events (1976-2014).'
+    hazard_type: convective_storm
+  - count: 1
+    descriptions:
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Albania. DesInventar records: 1 events with data out of 1 total drought
+      events (1993-1993).'
+    hazard_type: drought
+  - count: 12
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from earthquake (EARTHQUAKE) events in Albania. DesInventar records: 8 events
+      with data out of 185 total earthquake events (2014-2014).'
+    - 'Observed metres of transport networks destroyed from earthquake (EARTHQUAKE)
+      events in Albania. DesInventar records: 1 events with data out of 185 total
+      earthquake events (2014-2014).'
+    - 'Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE)
+      events in Albania. DesInventar records: 14 events with data out of 185 total
+      earthquake events (2014-2014).'
+    - 'Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Albania. DesInventar records: 8 events with data out of 185 total
+      earthquake events (2014-2014).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from earthquake
+      (EARTHQUAKE) events in Albania. DesInventar records: 5 events with data out
+      of 185 total earthquake events (2014-2014).'
+    - 'Observed health facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Albania. DesInventar records: 5 events with data out of 185 total
+      earthquake events (2014-2014).'
+    - 'Observed homes with non-structural damage, still habitable from earthquake
+      (EARTHQUAKE) events in Albania. DesInventar records: 92 events with data out
+      of 185 total earthquake events (2014-2014).'
+    - 'Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events
+      in Albania. DesInventar records: 66 events with data out of 185 total earthquake
+      events (2014-2014).'
+    - 'Observed persons injured or made sick directly by disaster events from earthquake
+      (EARTHQUAKE) events in Albania. DesInventar records: 18 events with data out
+      of 185 total earthquake events (2014-2014).'
+    - 'Observed total economic losses in local currency from earthquake (EARTHQUAKE)
+      events in Albania. DesInventar records: 78 events with data out of 185 total
+      earthquake events (2014-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from earthquake
+      (EARTHQUAKE) events in Albania. DesInventar records: 26 events with data out
+      of 185 total earthquake events (2014-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from earthquake
+      (LIQUEFACTION) events in Albania. DesInventar records: 2 events with data out
+      of 4 total earthquake events (2014-2014).'
+    hazard_type: earthquake
+  - count: 9
+    descriptions:
+    - 'Observed hectares of crops/woods destroyed or affected from extreme temperature
+      (COLD WAVE, FROST) events in Albania. DesInventar records: 55 events with data
+      out of 126 total extreme temperature events (1990-2012).'
+    - 'Observed deaths directly caused by disaster events from extreme temperature
+      (COLD WAVE, FROST) events in Albania. DesInventar records: 10 events with data
+      out of 126 total extreme temperature events (1990-2012).'
+    - 'Observed homes with non-structural damage, still habitable from extreme temperature
+      (COLD WAVE, FROST) events in Albania. DesInventar records: 2 events with data
+      out of 126 total extreme temperature events (1990-2012).'
+    - 'Observed persons injured or made sick directly by disaster events from extreme
+      temperature (COLD WAVE, FROST) events in Albania. DesInventar records: 10 events
+      with data out of 126 total extreme temperature events (1990-2012).'
+    - 'Observed total economic losses in local currency from extreme temperature (COLD
+      WAVE, FROST) events in Albania. DesInventar records: 5 events with data out
+      of 126 total extreme temperature events (1990-2012).'
+    - 'Observed livestock lost from extreme temperature (COLD WAVE, FROST) events
+      in Albania. DesInventar records: 10 events with data out of 126 total extreme
+      temperature events (1990-2012).'
+    - 'Observed deaths directly caused by disaster events from extreme temperature
+      (HEAT WAVE) events in Albania. DesInventar records: 9 events with data out of
+      22 total extreme temperature events (1998-2002).'
+    - 'Observed persons injured or made sick directly by disaster events from extreme
+      temperature (HEAT WAVE) events in Albania. DesInventar records: 11 events with
+      data out of 22 total extreme temperature events (1998-2002).'
+    - 'Observed livestock lost from extreme temperature (HEAT WAVE) events in Albania.
+      DesInventar records: 1 events with data out of 22 total extreme temperature
+      events (1998-2002).'
+    hazard_type: extreme_temperature
+  - count: 29
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 18 events
+      with data out of 949 total flood events (2002-2015).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLASH FLOOD,
+      FLOOD) events in Albania. DesInventar records: 474 events with data out of 949
+      total flood events (2002-2015).'
+    - 'Observed metres of transport networks destroyed from flood (FLASH FLOOD, FLOOD)
+      events in Albania. DesInventar records: 19 events with data out of 949 total
+      flood events (2002-2015).'
+    - 'Observed deaths directly caused by disaster events from flood (FLASH FLOOD,
+      FLOOD) events in Albania. DesInventar records: 44 events with data out of 949
+      total flood events (2002-2015).'
+    - 'Observed educational facilities destroyed or affected from flood (FLASH FLOOD,
+      FLOOD) events in Albania. DesInventar records: 13 events with data out of 949
+      total flood events (2002-2015).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 76 events with
+      data out of 949 total flood events (2002-2015).'
+    - 'Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD)
+      events in Albania. DesInventar records: 2 events with data out of 949 total
+      flood events (2002-2015).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLASH
+      FLOOD, FLOOD) events in Albania. DesInventar records: 208 events with data out
+      of 949 total flood events (2002-2015).'
+    - 'Observed homes destroyed beyond habitability from flood (FLASH FLOOD, FLOOD)
+      events in Albania. DesInventar records: 96 events with data out of 949 total
+      flood events (2002-2015).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 18 events with
+      data out of 949 total flood events (2002-2015).'
+    - 'Observed total economic losses in local currency from flood (FLASH FLOOD, FLOOD)
+      events in Albania. DesInventar records: 225 events with data out of 949 total
+      flood events (2002-2015).'
+    - 'Observed total economic losses in US Dollars from flood (FLASH FLOOD, FLOOD)
+      events in Albania. DesInventar records: 4 events with data out of 949 total
+      flood events (2002-2015).'
+    - 'Observed livestock lost from flood (FLASH FLOOD, FLOOD) events in Albania.
+      DesInventar records: 96 events with data out of 949 total flood events (2002-2015).'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLASH FLOOD, FLOOD) events in Albania. DesInventar records: 1 events with data
+      out of 949 total flood events (2002-2015).'
+    - 'Observed persons permanently relocated from homes from flood (FLASH FLOOD,
+      FLOOD) events in Albania. DesInventar records: 4 events with data out of 949
+      total flood events (2002-2015).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLASH
+      FLOOD, FLOOD) events in Albania. DesInventar records: 129 events with data out
+      of 949 total flood events (2002-2015).'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (RAINS) events in Albania. DesInventar records: 1 events with data
+      out of 217 total flood events (2007-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (RAINS) events
+      in Albania. DesInventar records: 49 events with data out of 217 total flood
+      events (2007-2013).'
+    - 'Observed metres of transport networks destroyed from flood (RAINS) events in
+      Albania. DesInventar records: 4 events with data out of 217 total flood events
+      (2007-2013).'
+    - 'Observed deaths directly caused by disaster events from flood (RAINS) events
+      in Albania. DesInventar records: 3 events with data out of 217 total flood events
+      (2007-2013).'
+    - 'Observed educational facilities destroyed or affected from flood (RAINS) events
+      in Albania. DesInventar records: 2 events with data out of 217 total flood events
+      (2007-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (RAINS) events in Albania. DesInventar records: 2 events with data out of 217
+      total flood events (2007-2013).'
+    - 'Observed homes with non-structural damage, still habitable from flood (RAINS)
+      events in Albania. DesInventar records: 40 events with data out of 217 total
+      flood events (2007-2013).'
+    - 'Observed homes destroyed beyond habitability from flood (RAINS) events in Albania.
+      DesInventar records: 43 events with data out of 217 total flood events (2007-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (RAINS) events in Albania. DesInventar records: 2 events with data out of 217
+      total flood events (2007-2013).'
+    - 'Observed total economic losses in local currency from flood (RAINS) events
+      in Albania. DesInventar records: 57 events with data out of 217 total flood
+      events (2007-2013).'
+    - 'Observed livestock lost from flood (RAINS) events in Albania. DesInventar records:
+      3 events with data out of 217 total flood events (2007-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (RAINS) events in Albania. DesInventar records: 1 events with data out of 217
+      total flood events (2007-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (RAINS)
+      events in Albania. DesInventar records: 42 events with data out of 217 total
+      flood events (2007-2013).'
+    hazard_type: flood
+  - count: 23
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (LANDSLIDE) events in Albania. DesInventar records: 5 events
+      with data out of 629 total landslide events (1995-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 17 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed metres of transport networks destroyed from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 30 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 40 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed educational facilities destroyed or affected from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 7 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from landslide
+      (LANDSLIDE) events in Albania. DesInventar records: 29 events with data out
+      of 629 total landslide events (1995-2013).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 117 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Albania. DesInventar records: 346 events with data out of 629 total landslide
+      events (1995-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (LANDSLIDE) events in Albania. DesInventar records: 15 events with data out
+      of 629 total landslide events (1995-2013).'
+    - 'Observed total economic losses in local currency from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 306 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed total economic losses in US Dollars from landslide (LANDSLIDE) events
+      in Albania. DesInventar records: 1 events with data out of 629 total landslide
+      events (1995-2013).'
+    - 'Observed livestock lost from landslide (LANDSLIDE) events in Albania. DesInventar
+      records: 3 events with data out of 629 total landslide events (1995-2013).'
+    - 'Observed persons permanently relocated from homes from landslide (LANDSLIDE)
+      events in Albania. DesInventar records: 5 events with data out of 629 total
+      landslide events (1995-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from landslide
+      (LANDSLIDE) events in Albania. DesInventar records: 249 events with data out
+      of 629 total landslide events (1995-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (SEDIMENTATION)
+      events in Albania. DesInventar records: 2 events with data out of 3 total landslide
+      events (1999-2005).'
+    - 'Observed deaths directly caused by disaster events from landslide (AVALANCHE)
+      events in Albania. DesInventar records: 17 events with data out of 25 total
+      landslide events (2010-2012).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (AVALANCHE)
+      events in Albania. DesInventar records: 3 events with data out of 25 total landslide
+      events (2010-2012).'
+    - 'Observed homes destroyed beyond habitability from landslide (AVALANCHE) events
+      in Albania. DesInventar records: 3 events with data out of 25 total landslide
+      events (2010-2012).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (AVALANCHE) events in Albania. DesInventar records: 8 events with data out of
+      25 total landslide events (2010-2012).'
+    - 'Observed total economic losses in local currency from landslide (AVALANCHE)
+      events in Albania. DesInventar records: 2 events with data out of 25 total landslide
+      events (2010-2012).'
+    - 'Observed livestock lost from landslide (AVALANCHE) events in Albania. DesInventar
+      records: 3 events with data out of 25 total landslide events (2010-2012).'
+    - 'Observed persons missing or unaccounted for after disaster events from landslide
+      (AVALANCHE) events in Albania. DesInventar records: 2 events with data out of
+      25 total landslide events (2010-2012).'
+    - 'Observed persons whose goods/services suffered serious damage from landslide
+      (AVALANCHE) events in Albania. DesInventar records: 1 events with data out of
+      25 total landslide events (2010-2012).'
+    hazard_type: landslide
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar
+      records: 55 events with data out of 891 total strong wind events (1973-2012).'
+    - 'Observed hectares of crops/woods destroyed or affected from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Albania. DesInventar records: 50 events with data
+      out of 891 total strong wind events (1973-2012).'
+    - 'Observed metres of transport networks destroyed from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Albania. DesInventar records: 4 events with data
+      out of 891 total strong wind events (1973-2012).'
+    - 'Observed deaths directly caused by disaster events from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Albania. DesInventar records: 45 events with data
+      out of 891 total strong wind events (1973-2012).'
+    - 'Observed educational facilities destroyed or affected from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Albania. DesInventar records: 28 events with data
+      out of 891 total strong wind events (1973-2012).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 16
+      events with data out of 891 total strong wind events (1973-2012).'
+    - 'Observed health facilities destroyed or affected from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Albania. DesInventar records: 1 events with data
+      out of 891 total strong wind events (1973-2012).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 86 events
+      with data out of 891 total strong wind events (1973-2012).'
+    - 'Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM,
+      WINDSTORM) events in Albania. DesInventar records: 108 events with data out
+      of 891 total strong wind events (1973-2012).'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 26
+      events with data out of 891 total strong wind events (1973-2012).'
+    - 'Observed total economic losses in local currency from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Albania. DesInventar records: 130 events with data
+      out of 891 total strong wind events (1973-2012).'
+    - 'Observed livestock lost from strong wind (SNOWSTORM, STORM, WINDSTORM) events
+      in Albania. DesInventar records: 65 events with data out of 891 total strong
+      wind events (1973-2012).'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 4
+      events with data out of 891 total strong wind events (1973-2012).'
+    - 'Observed persons whose goods/services suffered serious damage from strong wind
+      (SNOWSTORM, STORM, WINDSTORM) events in Albania. DesInventar records: 88 events
+      with data out of 891 total strong wind events (1973-2012).'
+    hazard_type: strong_wind
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Albania. DesInventar records: 4
+      events with data out of 1,383 total wildfire events (2003-2014).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Albania. DesInventar records: 716 events with data out
+      of 1,383 total wildfire events (2003-2014).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Albania. DesInventar records: 13 events with data out of 1,383
+      total wildfire events (2003-2014).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Albania. DesInventar records: 1 events with data out
+      of 1,383 total wildfire events (2003-2014).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from wildfire
+      (FIRE, FOREST FIRE) events in Albania. DesInventar records: 5 events with data
+      out of 1,383 total wildfire events (2003-2014).'
+    - 'Observed health facilities destroyed or affected from wildfire (FIRE, FOREST
+      FIRE) events in Albania. DesInventar records: 1 events with data out of 1,383
+      total wildfire events (2003-2014).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Albania. DesInventar records: 60 events with data out
+      of 1,383 total wildfire events (2003-2014).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Albania. DesInventar records: 46 events with data out of 1,383 total
+      wildfire events (2003-2014).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Albania. DesInventar records: 6 events with data
+      out of 1,383 total wildfire events (2003-2014).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Albania. DesInventar records: 65 events with data out of 1,383
+      total wildfire events (2003-2014).'
+    - 'Observed total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE)
+      events in Albania. DesInventar records: 23 events with data out of 1,383 total
+      wildfire events (2003-2014).'
+    - 'Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Albania.
+      DesInventar records: 11 events with data out of 1,383 total wildfire events
+      (2003-2014).'
+    - 'Observed persons permanently relocated from homes from wildfire (FIRE, FOREST
+      FIRE) events in Albania. DesInventar records: 5 events with data out of 1,383
+      total wildfire events (2003-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE, FOREST FIRE) events in Albania. DesInventar records: 37 events with data
+      out of 1,383 total wildfire events (2003-2014).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-colundrr_desinventar.md
+++ b/_datasets/rdls_lss-colundrr_desinventar.md
@@ -35,328 +35,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from coastal flood
-    (SURGE) events in Colombia. DesInventar records: 18 events with data out of 159
-    total coastal flood events (1984-2013)., Observed deaths directly caused by disaster
-    events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 144
-    events with data out of 888 total earthquake events (1986-2013)., Observed deaths
-    directly caused by disaster events from flood (FLOOD) events in Colombia. DesInventar
-    records: 756 events with data out of 15,109 total flood events (1984-2013)., Observed
-    deaths directly caused by disaster events from landslide (AVALANCHE) events in
-    Colombia. DesInventar records: 3 events with data out of 25 total landslide events
-    (1995-2009)., Observed deaths directly caused by disaster events from landslide
-    (LANDSLIDE) events in Colombia. DesInventar records: 1,409 events with data out
-    of 9,041 total landslide events (1984-2013)., Observed deaths directly caused
-    by disaster events from strong wind (HURRICANE) events in Colombia. DesInventar
-    records: 3 events with data out of 7 total strong wind events (1963-1988)., Observed
-    deaths directly caused by disaster events from strong wind (SNOWSTORM, STORM)
-    events in Colombia. DesInventar records: 75 events with data out of 348 total
-    strong wind events (1976-2013)., Observed deaths directly caused by disaster events
-    from tsunami (TSUNAMI) events in Colombia. DesInventar records: 4 events with
-    data out of 5 total tsunami events (1979-1979)., Observed deaths directly caused
-    by disaster events from wildfire (FIRE) events in Colombia. DesInventar records:
-    274 events with data out of 2,588 total wildfire events (1984-2013)., Observed
-    educational facilities destroyed or affected from coastal flood (SURGE) events
-    in Colombia. DesInventar records: 2 events with data out of 159 total coastal
-    flood events (1984-2013)., Observed educational facilities destroyed or affected
-    from convective storm (HAILSTORM) events in Colombia. DesInventar records: 4 events
-    with data out of 81 total convective storm events (1989-2013)., Observed educational
-    facilities destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar
-    records: 1 events with data out of 591 total drought events (1985-2012)., Observed
-    educational facilities destroyed or affected from earthquake (EARTHQUAKE) events
-    in Colombia. DesInventar records: 146 events with data out of 888 total earthquake
-    events (1986-2013)., Observed educational facilities destroyed or affected from
-    flood (FLOOD) events in Colombia. DesInventar records: 455 events with data out
-    of 15,109 total flood events (1984-2013)., Observed educational facilities destroyed
-    or affected from landslide (AVALANCHE) events in Colombia. DesInventar records:
-    2 events with data out of 25 total landslide events (1995-2009)., Observed educational
-    facilities destroyed or affected from landslide (LANDSLIDE) events in Colombia.
-    DesInventar records: 262 events with data out of 9,041 total landslide events
-    (1984-2013)., Observed educational facilities destroyed or affected from strong
-    wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 17 events with
-    data out of 348 total strong wind events (1976-2013)., Observed educational facilities
-    destroyed or affected from wildfire (FIRE) events in Colombia. DesInventar records:
-    27 events with data out of 2,588 total wildfire events (1984-2013)., Observed
-    health facilities destroyed or affected from coastal flood (SURGE) events in Colombia.
-    DesInventar records: 1 events with data out of 159 total coastal flood events
-    (1984-2013)., Observed health facilities destroyed or affected from convective
-    storm (HAILSTORM) events in Colombia. DesInventar records: 2 events with data
-    out of 81 total convective storm events (1989-2013)., Observed health facilities
-    destroyed or affected from drought (DROUGHT) events in Colombia. DesInventar records:
-    1 events with data out of 591 total drought events (1985-2012)., Observed health
-    facilities destroyed or affected from earthquake (EARTHQUAKE) events in Colombia.
-    DesInventar records: 46 events with data out of 888 total earthquake events (1986-2013).,
-    Observed health facilities destroyed or affected from flood (FLOOD) events in
-    Colombia. DesInventar records: 88 events with data out of 15,109 total flood events
-    (1984-2013)., Observed health facilities destroyed or affected from landslide
-    (LANDSLIDE) events in Colombia. DesInventar records: 34 events with data out of
-    9,041 total landslide events (1984-2013)., Observed health facilities destroyed
-    or affected from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar
-    records: 5 events with data out of 348 total strong wind events (1976-2013).,
-    Observed health facilities destroyed or affected from tsunami (TSUNAMI) events
-    in Colombia. DesInventar records: 1 events with data out of 5 total tsunami events
-    (1979-1979)., Observed health facilities destroyed or affected from wildfire (FIRE)
-    events in Colombia. DesInventar records: 14 events with data out of 2,588 total
-    wildfire events (1984-2013)., Observed hectares of crops/woods destroyed or affected
-    from coastal flood (SURGE) events in Colombia. DesInventar records: 1 events with
-    data out of 159 total coastal flood events (1984-2013)., Observed hectares of
-    crops/woods destroyed or affected from convective storm (HAILSTORM) events in
-    Colombia. DesInventar records: 6 events with data out of 81 total convective storm
-    events (1989-2013)., Observed hectares of crops/woods destroyed or affected from
-    drought (DROUGHT) events in Colombia. DesInventar records: 25 events with data
-    out of 591 total drought events (1985-2012)., Observed hectares of crops/woods
-    destroyed or affected from earthquake (EARTHQUAKE) events in Colombia. DesInventar
-    records: 1 events with data out of 888 total earthquake events (1986-2013)., Observed
-    hectares of crops/woods destroyed or affected from extreme temperature (FROST)
-    events in Colombia. DesInventar records: 20 events with data out of 62 total extreme
-    temperature events (1985-2013)., Observed hectares of crops/woods destroyed or
-    affected from flood (FLOOD) events in Colombia. DesInventar records: 1,015 events
-    with data out of 15,109 total flood events (1984-2013)., Observed hectares of
-    crops/woods destroyed or affected from landslide (AVALANCHE) events in Colombia.
-    DesInventar records: 1 events with data out of 25 total landslide events (1995-2009).,
-    Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
-    events in Colombia. DesInventar records: 212 events with data out of 9,041 total
-    landslide events (1984-2013)., Observed hectares of crops/woods destroyed or affected
-    from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 7
-    events with data out of 348 total strong wind events (1976-2013)., Observed hectares
-    of crops/woods destroyed or affected from wildfire (FIRE) events in Colombia.
-    DesInventar records: 10 events with data out of 2,588 total wildfire events (1984-2013).,
-    Observed homes destroyed beyond habitability from coastal flood (SURGE) events
-    in Colombia. DesInventar records: 52 events with data out of 159 total coastal
-    flood events (1984-2013)., Observed homes destroyed beyond habitability from convective
-    storm (HAILSTORM) events in Colombia. DesInventar records: 6 events with data
-    out of 81 total convective storm events (1989-2013)., Observed homes destroyed
-    beyond habitability from earthquake (EARTHQUAKE) events in Colombia. DesInventar
-    records: 359 events with data out of 888 total earthquake events (1986-2013).,
-    Observed homes destroyed beyond habitability from flood (FLOOD) events in Colombia.
-    DesInventar records: 2,279 events with data out of 15,109 total flood events (1984-2013).,
-    Observed homes destroyed beyond habitability from landslide (AVALANCHE) events
-    in Colombia. DesInventar records: 12 events with data out of 25 total landslide
-    events (1995-2009)., Observed homes destroyed beyond habitability from landslide
-    (LANDSLIDE) events in Colombia. DesInventar records: 2,060 events with data out
-    of 9,041 total landslide events (1984-2013)., Observed homes destroyed beyond
-    habitability from strong wind (HURRICANE) events in Colombia. DesInventar records:
-    5 events with data out of 7 total strong wind events (1963-1988)., Observed homes
-    destroyed beyond habitability from strong wind (SNOWSTORM, STORM) events in Colombia.
-    DesInventar records: 94 events with data out of 348 total strong wind events (1976-2013).,
-    Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in
-    Colombia. DesInventar records: 3 events with data out of 5 total tsunami events
-    (1979-1979)., Observed homes destroyed beyond habitability from wildfire (FIRE)
-    events in Colombia. DesInventar records: 922 events with data out of 2,588 total
-    wildfire events (1984-2013)., Observed homes with non-structural damage, still
-    habitable from coastal flood (SURGE) events in Colombia. DesInventar records:
-    33 events with data out of 159 total coastal flood events (1984-2013)., Observed
-    homes with non-structural damage, still habitable from convective storm (HAILSTORM)
-    events in Colombia. DesInventar records: 30 events with data out of 81 total convective
-    storm events (1989-2013)., Observed homes with non-structural damage, still habitable
-    from drought (DROUGHT) events in Colombia. DesInventar records: 2 events with
-    data out of 591 total drought events (1985-2012)., Observed homes with non-structural
-    damage, still habitable from earthquake (EARTHQUAKE) events in Colombia. DesInventar
-    records: 362 events with data out of 888 total earthquake events (1986-2013).,
-    Observed homes with non-structural damage, still habitable from flood (FLOOD)
-    events in Colombia. DesInventar records: 5,361 events with data out of 15,109
-    total flood events (1984-2013)., Observed homes with non-structural damage, still
-    habitable from landslide (AVALANCHE) events in Colombia. DesInventar records:
-    14 events with data out of 25 total landslide events (1995-2009)., Observed homes
-    with non-structural damage, still habitable from landslide (LANDSLIDE) events
-    in Colombia. DesInventar records: 2,153 events with data out of 9,041 total landslide
-    events (1984-2013)., Observed homes with non-structural damage, still habitable
-    from strong wind (HURRICANE) events in Colombia. DesInventar records: 2 events
-    with data out of 7 total strong wind events (1963-1988)., Observed homes with
-    non-structural damage, still habitable from strong wind (SNOWSTORM, STORM) events
-    in Colombia. DesInventar records: 48 events with data out of 348 total strong
-    wind events (1976-2013)., Observed homes with non-structural damage, still habitable
-    from tsunami (TSUNAMI) events in Colombia. DesInventar records: 5 events with
-    data out of 5 total tsunami events (1979-1979)., Observed homes with non-structural
-    damage, still habitable from wildfire (FIRE) events in Colombia. DesInventar records:
-    401 events with data out of 2,588 total wildfire events (1984-2013)., Observed
-    livestock lost from convective storm (HAILSTORM) events in Colombia. DesInventar
-    records: 1 events with data out of 81 total convective storm events (1989-2013).,
-    Observed livestock lost from drought (DROUGHT) events in Colombia. DesInventar
-    records: 6 events with data out of 591 total drought events (1985-2012)., Observed
-    livestock lost from extreme temperature (FROST) events in Colombia. DesInventar
-    records: 1 events with data out of 62 total extreme temperature events (1985-2013).,
-    Observed livestock lost from flood (FLOOD) events in Colombia. DesInventar records:
-    27 events with data out of 15,109 total flood events (1984-2013)., Observed livestock
-    lost from landslide (LANDSLIDE) events in Colombia. DesInventar records: 4 events
-    with data out of 9,041 total landslide events (1984-2013)., Observed livestock
-    lost from wildfire (FIRE) events in Colombia. DesInventar records: 1 events with
-    data out of 2,588 total wildfire events (1984-2013)., Observed metres of transport
-    networks destroyed from coastal flood (SURGE) events in Colombia. DesInventar
-    records: 2 events with data out of 159 total coastal flood events (1984-2013).,
-    Observed metres of transport networks destroyed from convective storm (HAILSTORM)
-    events in Colombia. DesInventar records: 1 events with data out of 81 total convective
-    storm events (1989-2013)., Observed metres of transport networks destroyed from
-    earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 19 events with
-    data out of 888 total earthquake events (1986-2013)., Observed metres of transport
-    networks destroyed from flood (FLOOD) events in Colombia. DesInventar records:
-    484 events with data out of 15,109 total flood events (1984-2013)., Observed metres
-    of transport networks destroyed from landslide (LANDSLIDE) events in Colombia.
-    DesInventar records: 747 events with data out of 9,041 total landslide events
-    (1984-2013)., Observed metres of transport networks destroyed from strong wind
-    (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of
-    7 total strong wind events (1963-1988)., Observed metres of transport networks
-    destroyed from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar
-    records: 5 events with data out of 348 total strong wind events (1976-2013).,
-    Observed metres of transport networks destroyed from wildfire (FIRE) events in
-    Colombia. DesInventar records: 1 events with data out of 2,588 total wildfire
-    events (1984-2013)., Observed persons indirectly affected (disruption to services,
-    commerce, work) from coastal flood (SURGE) events in Colombia. DesInventar records:
-    52 events with data out of 159 total coastal flood events (1984-2013)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from convective
-    storm (HAILSTORM) events in Colombia. DesInventar records: 39 events with data
-    out of 81 total convective storm events (1989-2013)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from drought (DROUGHT) events
-    in Colombia. DesInventar records: 115 events with data out of 591 total drought
-    events (1985-2012)., Observed persons indirectly affected (disruption to services,
-    commerce, work) from earthquake (EARTHQUAKE) events in Colombia. DesInventar records:
-    211 events with data out of 888 total earthquake events (1986-2013)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from extreme
-    temperature (FROST) events in Colombia. DesInventar records: 6 events with data
-    out of 62 total extreme temperature events (1985-2013)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from flood (FLOOD) events in
-    Colombia. DesInventar records: 8,904 events with data out of 15,109 total flood
-    events (1984-2013)., Observed persons indirectly affected (disruption to services,
-    commerce, work) from landslide (AVALANCHE) events in Colombia. DesInventar records:
-    23 events with data out of 25 total landslide events (1995-2009)., Observed persons
-    indirectly affected (disruption to services, commerce, work) from landslide (LANDSLIDE)
-    events in Colombia. DesInventar records: 3,212 events with data out of 9,041 total
-    landslide events (1984-2013)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from strong wind (HURRICANE) events in Colombia.
-    DesInventar records: 4 events with data out of 7 total strong wind events (1963-1988).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 42
-    events with data out of 348 total strong wind events (1976-2013)., Observed persons
-    indirectly affected (disruption to services, commerce, work) from tsunami (TSUNAMI)
-    events in Colombia. DesInventar records: 1 events with data out of 5 total tsunami
-    events (1979-1979)., Observed persons indirectly affected (disruption to services,
-    commerce, work) from wildfire (FIRE) events in Colombia. DesInventar records:
-    893 events with data out of 2,588 total wildfire events (1984-2013)., Observed
-    persons injured or made sick directly by disaster events from coastal flood (SURGE)
-    events in Colombia. DesInventar records: 4 events with data out of 159 total coastal
-    flood events (1984-2013)., Observed persons injured or made sick directly by disaster
-    events from convective storm (HAILSTORM) events in Colombia. DesInventar records:
-    2 events with data out of 81 total convective storm events (1989-2013)., Observed
-    persons injured or made sick directly by disaster events from earthquake (EARTHQUAKE)
-    events in Colombia. DesInventar records: 158 events with data out of 888 total
-    earthquake events (1986-2013)., Observed persons injured or made sick directly
-    by disaster events from flood (FLOOD) events in Colombia. DesInventar records:
-    237 events with data out of 15,109 total flood events (1984-2013)., Observed persons
-    injured or made sick directly by disaster events from landslide (AVALANCHE) events
-    in Colombia. DesInventar records: 3 events with data out of 25 total landslide
-    events (1995-2009)., Observed persons injured or made sick directly by disaster
-    events from landslide (LANDSLIDE) events in Colombia. DesInventar records: 749
-    events with data out of 9,041 total landslide events (1984-2013)., Observed persons
-    injured or made sick directly by disaster events from strong wind (HURRICANE)
-    events in Colombia. DesInventar records: 1 events with data out of 7 total strong
-    wind events (1963-1988)., Observed persons injured or made sick directly by disaster
-    events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
-    54 events with data out of 348 total strong wind events (1976-2013)., Observed
-    persons injured or made sick directly by disaster events from tsunami (TSUNAMI)
-    events in Colombia. DesInventar records: 5 events with data out of 5 total tsunami
-    events (1979-1979)., Observed persons injured or made sick directly by disaster
-    events from wildfire (FIRE) events in Colombia. DesInventar records: 417 events
-    with data out of 2,588 total wildfire events (1984-2013)., Observed persons missing
-    or unaccounted for after disaster events from coastal flood (SURGE) events in
-    Colombia. DesInventar records: 9 events with data out of 159 total coastal flood
-    events (1984-2013)., Observed persons missing or unaccounted for after disaster
-    events from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 22
-    events with data out of 888 total earthquake events (1986-2013)., Observed persons
-    missing or unaccounted for after disaster events from flood (FLOOD) events in
-    Colombia. DesInventar records: 199 events with data out of 15,109 total flood
-    events (1984-2013)., Observed persons missing or unaccounted for after disaster
-    events from landslide (AVALANCHE) events in Colombia. DesInventar records: 2 events
-    with data out of 25 total landslide events (1995-2009)., Observed persons missing
-    or unaccounted for after disaster events from landslide (LANDSLIDE) events in
-    Colombia. DesInventar records: 140 events with data out of 9,041 total landslide
-    events (1984-2013)., Observed persons missing or unaccounted for after disaster
-    events from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
-    4 events with data out of 348 total strong wind events (1976-2013)., Observed
-    persons missing or unaccounted for after disaster events from tsunami (TSUNAMI)
-    events in Colombia. DesInventar records: 3 events with data out of 5 total tsunami
-    events (1979-1979)., Observed persons missing or unaccounted for after disaster
-    events from wildfire (FIRE) events in Colombia. DesInventar records: 4 events
-    with data out of 2,588 total wildfire events (1984-2013)., Observed persons permanently
-    relocated from homes from flood (FLOOD) events in Colombia. DesInventar records:
-    23 events with data out of 15,109 total flood events (1984-2013)., Observed persons
-    permanently relocated from homes from landslide (LANDSLIDE) events in Colombia.
-    DesInventar records: 7 events with data out of 9,041 total landslide events (1984-2013).,
-    Observed persons temporarily evacuated from homes or workplaces from coastal flood
-    (SURGE) events in Colombia. DesInventar records: 8 events with data out of 159
-    total coastal flood events (1984-2013)., Observed persons temporarily evacuated
-    from homes or workplaces from earthquake (EARTHQUAKE) events in Colombia. DesInventar
-    records: 11 events with data out of 888 total earthquake events (1986-2013).,
-    Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD)
-    events in Colombia. DesInventar records: 423 events with data out of 15,109 total
-    flood events (1984-2013)., Observed persons temporarily evacuated from homes or
-    workplaces from landslide (LANDSLIDE) events in Colombia. DesInventar records:
-    142 events with data out of 9,041 total landslide events (1984-2013)., Observed
-    persons temporarily evacuated from homes or workplaces from strong wind (HURRICANE)
-    events in Colombia. DesInventar records: 1 events with data out of 7 total strong
-    wind events (1963-1988)., Observed persons temporarily evacuated from homes or
-    workplaces from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar
-    records: 4 events with data out of 348 total strong wind events (1976-2013).,
-    Observed persons temporarily evacuated from homes or workplaces from wildfire
-    (FIRE) events in Colombia. DesInventar records: 18 events with data out of 2,588
-    total wildfire events (1984-2013)., Observed persons whose goods/services suffered
-    serious damage from coastal flood (SURGE) events in Colombia. DesInventar records:
-    12 events with data out of 159 total coastal flood events (1984-2013)., Observed
-    persons whose goods/services suffered serious damage from convective storm (HAILSTORM)
-    events in Colombia. DesInventar records: 4 events with data out of 81 total convective
-    storm events (1989-2013)., Observed persons whose goods/services suffered serious
-    damage from drought (DROUGHT) events in Colombia. DesInventar records: 1 events
-    with data out of 591 total drought events (1985-2012)., Observed persons whose
-    goods/services suffered serious damage from earthquake (EARTHQUAKE) events in
-    Colombia. DesInventar records: 195 events with data out of 888 total earthquake
-    events (1986-2013)., Observed persons whose goods/services suffered serious damage
-    from extreme temperature (FROST) events in Colombia. DesInventar records: 2 events
-    with data out of 62 total extreme temperature events (1985-2013)., Observed persons
-    whose goods/services suffered serious damage from flood (FLOOD) events in Colombia.
-    DesInventar records: 1,131 events with data out of 15,109 total flood events (1984-2013).,
-    Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE)
-    events in Colombia. DesInventar records: 471 events with data out of 9,041 total
-    landslide events (1984-2013)., Observed persons whose goods/services suffered
-    serious damage from strong wind (HURRICANE) events in Colombia. DesInventar records:
-    1 events with data out of 7 total strong wind events (1963-1988)., Observed persons
-    whose goods/services suffered serious damage from strong wind (SNOWSTORM, STORM)
-    events in Colombia. DesInventar records: 41 events with data out of 348 total
-    strong wind events (1976-2013)., Observed persons whose goods/services suffered
-    serious damage from wildfire (FIRE) events in Colombia. DesInventar records: 476
-    events with data out of 2,588 total wildfire events (1984-2013)., Observed total
-    economic losses in US Dollars from earthquake (EARTHQUAKE) events in Colombia.
-    DesInventar records: 2 events with data out of 888 total earthquake events (1986-2013).,
-    Observed total economic losses in US Dollars from flood (FLOOD) events in Colombia.
-    DesInventar records: 1 events with data out of 15,109 total flood events (1984-2013).,
-    Observed total economic losses in US Dollars from landslide (LANDSLIDE) events
-    in Colombia. DesInventar records: 4 events with data out of 9,041 total landslide
-    events (1984-2013)., Observed total economic losses in US Dollars from landslide
-    (SEDIMENTATION) events in Colombia. DesInventar records: 1 events with data out
-    of 12 total landslide events (1984-1985)., Observed total economic losses in US
-    Dollars from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
-    1 events with data out of 348 total strong wind events (1976-2013)., Observed
-    total economic losses in local currency from coastal flood (SURGE) events in Colombia.
-    DesInventar records: 8 events with data out of 159 total coastal flood events
-    (1984-2013)., Observed total economic losses in local currency from convective
-    storm (HAILSTORM) events in Colombia. DesInventar records: 11 events with data
-    out of 81 total convective storm events (1989-2013)., Observed total economic
-    losses in local currency from drought (DROUGHT) events in Colombia. DesInventar
-    records: 25 events with data out of 591 total drought events (1985-2012)., Observed
-    total economic losses in local currency from earthquake (EARTHQUAKE) events in
-    Colombia. DesInventar records: 23 events with data out of 888 total earthquake
-    events (1986-2013)., Observed total economic losses in local currency from extreme
-    temperature (FROST) events in Colombia. DesInventar records: 7 events with data
-    out of 62 total extreme temperature events (1985-2013)., Observed total economic
-    losses in local currency from flood (FLOOD) events in Colombia. DesInventar records:
-    958 events with data out of 15,109 total flood events (1984-2013)., Observed total
-    economic losses in local currency from landslide (LANDSLIDE) events in Colombia.
-    DesInventar records: 205 events with data out of 9,041 total landslide events
-    (1984-2013)., Observed total economic losses in local currency from strong wind
-    (HURRICANE) events in Colombia. DesInventar records: 1 events with data out of
-    7 total strong wind events (1963-1988)., Observed total economic losses in local
-    currency from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
-    38 events with data out of 348 total strong wind events (1976-2013)., Observed
-    total economic losses in local currency from wildfire (FIRE) events in Colombia.
-    DesInventar records: 901 events with data out of 2,588 total wildfire events (1984-2013).'
+  description: 136 loss records across 10 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -369,6 +48,441 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 136
+  loss_groups:
+  - count: 13
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from coastal flood (SURGE) events in Colombia. DesInventar records: 52 events
+      with data out of 159 total coastal flood events (1984-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from coastal flood (SURGE)
+      events in Colombia. DesInventar records: 1 events with data out of 159 total
+      coastal flood events (1984-2013).'
+    - 'Observed metres of transport networks destroyed from coastal flood (SURGE)
+      events in Colombia. DesInventar records: 2 events with data out of 159 total
+      coastal flood events (1984-2013).'
+    - 'Observed deaths directly caused by disaster events from coastal flood (SURGE)
+      events in Colombia. DesInventar records: 18 events with data out of 159 total
+      coastal flood events (1984-2013).'
+    - 'Observed educational facilities destroyed or affected from coastal flood (SURGE)
+      events in Colombia. DesInventar records: 2 events with data out of 159 total
+      coastal flood events (1984-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from coastal
+      flood (SURGE) events in Colombia. DesInventar records: 8 events with data out
+      of 159 total coastal flood events (1984-2013).'
+    - 'Observed health facilities destroyed or affected from coastal flood (SURGE)
+      events in Colombia. DesInventar records: 1 events with data out of 159 total
+      coastal flood events (1984-2013).'
+    - 'Observed homes with non-structural damage, still habitable from coastal flood
+      (SURGE) events in Colombia. DesInventar records: 33 events with data out of
+      159 total coastal flood events (1984-2013).'
+    - 'Observed homes destroyed beyond habitability from coastal flood (SURGE) events
+      in Colombia. DesInventar records: 52 events with data out of 159 total coastal
+      flood events (1984-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from coastal
+      flood (SURGE) events in Colombia. DesInventar records: 4 events with data out
+      of 159 total coastal flood events (1984-2013).'
+    - 'Observed total economic losses in local currency from coastal flood (SURGE)
+      events in Colombia. DesInventar records: 8 events with data out of 159 total
+      coastal flood events (1984-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from coastal
+      flood (SURGE) events in Colombia. DesInventar records: 9 events with data out
+      of 159 total coastal flood events (1984-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from coastal
+      flood (SURGE) events in Colombia. DesInventar records: 12 events with data out
+      of 159 total coastal flood events (1984-2013).'
+    hazard_type: coastal_flood
+  - count: 11
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from convective storm (HAILSTORM) events in Colombia. DesInventar records: 39
+      events with data out of 81 total convective storm events (1989-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from convective storm
+      (HAILSTORM) events in Colombia. DesInventar records: 6 events with data out
+      of 81 total convective storm events (1989-2013).'
+    - 'Observed metres of transport networks destroyed from convective storm (HAILSTORM)
+      events in Colombia. DesInventar records: 1 events with data out of 81 total
+      convective storm events (1989-2013).'
+    - 'Observed educational facilities destroyed or affected from convective storm
+      (HAILSTORM) events in Colombia. DesInventar records: 4 events with data out
+      of 81 total convective storm events (1989-2013).'
+    - 'Observed health facilities destroyed or affected from convective storm (HAILSTORM)
+      events in Colombia. DesInventar records: 2 events with data out of 81 total
+      convective storm events (1989-2013).'
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (HAILSTORM) events in Colombia. DesInventar records: 30 events with data
+      out of 81 total convective storm events (1989-2013).'
+    - 'Observed homes destroyed beyond habitability from convective storm (HAILSTORM)
+      events in Colombia. DesInventar records: 6 events with data out of 81 total
+      convective storm events (1989-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from convective
+      storm (HAILSTORM) events in Colombia. DesInventar records: 2 events with data
+      out of 81 total convective storm events (1989-2013).'
+    - 'Observed total economic losses in local currency from convective storm (HAILSTORM)
+      events in Colombia. DesInventar records: 11 events with data out of 81 total
+      convective storm events (1989-2013).'
+    - 'Observed livestock lost from convective storm (HAILSTORM) events in Colombia.
+      DesInventar records: 1 events with data out of 81 total convective storm events
+      (1989-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from convective
+      storm (HAILSTORM) events in Colombia. DesInventar records: 4 events with data
+      out of 81 total convective storm events (1989-2013).'
+    hazard_type: convective_storm
+  - count: 8
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Colombia. DesInventar records: 115 events with
+      data out of 591 total drought events (1985-2012).'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Colombia. DesInventar records: 25 events with data out of 591 total
+      drought events (1985-2012).'
+    - 'Observed educational facilities destroyed or affected from drought (DROUGHT)
+      events in Colombia. DesInventar records: 1 events with data out of 591 total
+      drought events (1985-2012).'
+    - 'Observed health facilities destroyed or affected from drought (DROUGHT) events
+      in Colombia. DesInventar records: 1 events with data out of 591 total drought
+      events (1985-2012).'
+    - 'Observed homes with non-structural damage, still habitable from drought (DROUGHT)
+      events in Colombia. DesInventar records: 2 events with data out of 591 total
+      drought events (1985-2012).'
+    - 'Observed total economic losses in local currency from drought (DROUGHT) events
+      in Colombia. DesInventar records: 25 events with data out of 591 total drought
+      events (1985-2012).'
+    - 'Observed livestock lost from drought (DROUGHT) events in Colombia. DesInventar
+      records: 6 events with data out of 591 total drought events (1985-2012).'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (DROUGHT) events in Colombia. DesInventar records: 1 events with data out of
+      591 total drought events (1985-2012).'
+    hazard_type: drought
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from earthquake (EARTHQUAKE) events in Colombia. DesInventar records: 211 events
+      with data out of 888 total earthquake events (1986-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from earthquake (EARTHQUAKE)
+      events in Colombia. DesInventar records: 1 events with data out of 888 total
+      earthquake events (1986-2013).'
+    - 'Observed metres of transport networks destroyed from earthquake (EARTHQUAKE)
+      events in Colombia. DesInventar records: 19 events with data out of 888 total
+      earthquake events (1986-2013).'
+    - 'Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE)
+      events in Colombia. DesInventar records: 144 events with data out of 888 total
+      earthquake events (1986-2013).'
+    - 'Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Colombia. DesInventar records: 146 events with data out of 888 total
+      earthquake events (1986-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from earthquake
+      (EARTHQUAKE) events in Colombia. DesInventar records: 11 events with data out
+      of 888 total earthquake events (1986-2013).'
+    - 'Observed health facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Colombia. DesInventar records: 46 events with data out of 888 total
+      earthquake events (1986-2013).'
+    - 'Observed homes with non-structural damage, still habitable from earthquake
+      (EARTHQUAKE) events in Colombia. DesInventar records: 362 events with data out
+      of 888 total earthquake events (1986-2013).'
+    - 'Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events
+      in Colombia. DesInventar records: 359 events with data out of 888 total earthquake
+      events (1986-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from earthquake
+      (EARTHQUAKE) events in Colombia. DesInventar records: 158 events with data out
+      of 888 total earthquake events (1986-2013).'
+    - 'Observed total economic losses in local currency from earthquake (EARTHQUAKE)
+      events in Colombia. DesInventar records: 23 events with data out of 888 total
+      earthquake events (1986-2013).'
+    - 'Observed total economic losses in US Dollars from earthquake (EARTHQUAKE) events
+      in Colombia. DesInventar records: 2 events with data out of 888 total earthquake
+      events (1986-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from earthquake
+      (EARTHQUAKE) events in Colombia. DesInventar records: 22 events with data out
+      of 888 total earthquake events (1986-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from earthquake
+      (EARTHQUAKE) events in Colombia. DesInventar records: 195 events with data out
+      of 888 total earthquake events (1986-2013).'
+    hazard_type: earthquake
+  - count: 5
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from extreme temperature (FROST) events in Colombia. DesInventar records: 6
+      events with data out of 62 total extreme temperature events (1985-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from extreme temperature
+      (FROST) events in Colombia. DesInventar records: 20 events with data out of
+      62 total extreme temperature events (1985-2013).'
+    - 'Observed total economic losses in local currency from extreme temperature (FROST)
+      events in Colombia. DesInventar records: 7 events with data out of 62 total
+      extreme temperature events (1985-2013).'
+    - 'Observed livestock lost from extreme temperature (FROST) events in Colombia.
+      DesInventar records: 1 events with data out of 62 total extreme temperature
+      events (1985-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from extreme
+      temperature (FROST) events in Colombia. DesInventar records: 2 events with data
+      out of 62 total extreme temperature events (1985-2013).'
+    hazard_type: extreme_temperature
+  - count: 16
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Colombia. DesInventar records: 8,904 events with
+      data out of 15,109 total flood events (1984-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Colombia. DesInventar records: 1,015 events with data out of 15,109 total
+      flood events (1984-2013).'
+    - 'Observed metres of transport networks destroyed from flood (FLOOD) events in
+      Colombia. DesInventar records: 484 events with data out of 15,109 total flood
+      events (1984-2013).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Colombia. DesInventar records: 756 events with data out of 15,109 total flood
+      events (1984-2013).'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Colombia. DesInventar records: 455 events with data out of 15,109 total flood
+      events (1984-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLOOD) events in Colombia. DesInventar records: 423 events with data out of
+      15,109 total flood events (1984-2013).'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Colombia. DesInventar records: 88 events with data out of 15,109 total flood
+      events (1984-2013).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Colombia. DesInventar records: 5,361 events with data out of 15,109
+      total flood events (1984-2013).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Colombia.
+      DesInventar records: 2,279 events with data out of 15,109 total flood events
+      (1984-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Colombia. DesInventar records: 237 events with data out of
+      15,109 total flood events (1984-2013).'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Colombia. DesInventar records: 958 events with data out of 15,109 total flood
+      events (1984-2013).'
+    - 'Observed total economic losses in US Dollars from flood (FLOOD) events in Colombia.
+      DesInventar records: 1 events with data out of 15,109 total flood events (1984-2013).'
+    - 'Observed livestock lost from flood (FLOOD) events in Colombia. DesInventar
+      records: 27 events with data out of 15,109 total flood events (1984-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLOOD) events in Colombia. DesInventar records: 199 events with data out of
+      15,109 total flood events (1984-2013).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Colombia. DesInventar records: 23 events with data out of 15,109 total flood
+      events (1984-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Colombia. DesInventar records: 1,131 events with data out of 15,109
+      total flood events (1984-2013).'
+    hazard_type: flood
+  - count: 25
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (LANDSLIDE) events in Colombia. DesInventar records: 3,212 events
+      with data out of 9,041 total landslide events (1984-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 212 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed metres of transport networks destroyed from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 747 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 1,409 events with data out of 9,041
+      total landslide events (1984-2013).'
+    - 'Observed educational facilities destroyed or affected from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 262 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from landslide
+      (LANDSLIDE) events in Colombia. DesInventar records: 142 events with data out
+      of 9,041 total landslide events (1984-2013).'
+    - 'Observed health facilities destroyed or affected from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 34 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 2,153 events with data out of 9,041
+      total landslide events (1984-2013).'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Colombia. DesInventar records: 2,060 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (LANDSLIDE) events in Colombia. DesInventar records: 749 events with data out
+      of 9,041 total landslide events (1984-2013).'
+    - 'Observed total economic losses in local currency from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 205 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed total economic losses in US Dollars from landslide (LANDSLIDE) events
+      in Colombia. DesInventar records: 4 events with data out of 9,041 total landslide
+      events (1984-2013).'
+    - 'Observed livestock lost from landslide (LANDSLIDE) events in Colombia. DesInventar
+      records: 4 events with data out of 9,041 total landslide events (1984-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from landslide
+      (LANDSLIDE) events in Colombia. DesInventar records: 140 events with data out
+      of 9,041 total landslide events (1984-2013).'
+    - 'Observed persons permanently relocated from homes from landslide (LANDSLIDE)
+      events in Colombia. DesInventar records: 7 events with data out of 9,041 total
+      landslide events (1984-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from landslide
+      (LANDSLIDE) events in Colombia. DesInventar records: 471 events with data out
+      of 9,041 total landslide events (1984-2013).'
+    - 'Observed total economic losses in US Dollars from landslide (SEDIMENTATION)
+      events in Colombia. DesInventar records: 1 events with data out of 12 total
+      landslide events (1984-1985).'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (AVALANCHE) events in Colombia. DesInventar records: 23 events
+      with data out of 25 total landslide events (1995-2009).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (AVALANCHE)
+      events in Colombia. DesInventar records: 1 events with data out of 25 total
+      landslide events (1995-2009).'
+    - 'Observed deaths directly caused by disaster events from landslide (AVALANCHE)
+      events in Colombia. DesInventar records: 3 events with data out of 25 total
+      landslide events (1995-2009).'
+    - 'Observed educational facilities destroyed or affected from landslide (AVALANCHE)
+      events in Colombia. DesInventar records: 2 events with data out of 25 total
+      landslide events (1995-2009).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (AVALANCHE)
+      events in Colombia. DesInventar records: 14 events with data out of 25 total
+      landslide events (1995-2009).'
+    - 'Observed homes destroyed beyond habitability from landslide (AVALANCHE) events
+      in Colombia. DesInventar records: 12 events with data out of 25 total landslide
+      events (1995-2009).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (AVALANCHE) events in Colombia. DesInventar records: 3 events with data out
+      of 25 total landslide events (1995-2009).'
+    - 'Observed persons missing or unaccounted for after disaster events from landslide
+      (AVALANCHE) events in Colombia. DesInventar records: 2 events with data out
+      of 25 total landslide events (1995-2009).'
+    hazard_type: landslide
+  - count: 23
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (SNOWSTORM, STORM) events in Colombia. DesInventar records:
+      42 events with data out of 348 total strong wind events (1976-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from strong wind (SNOWSTORM,
+      STORM) events in Colombia. DesInventar records: 7 events with data out of 348
+      total strong wind events (1976-2013).'
+    - 'Observed metres of transport networks destroyed from strong wind (SNOWSTORM,
+      STORM) events in Colombia. DesInventar records: 5 events with data out of 348
+      total strong wind events (1976-2013).'
+    - 'Observed deaths directly caused by disaster events from strong wind (SNOWSTORM,
+      STORM) events in Colombia. DesInventar records: 75 events with data out of 348
+      total strong wind events (1976-2013).'
+    - 'Observed educational facilities destroyed or affected from strong wind (SNOWSTORM,
+      STORM) events in Colombia. DesInventar records: 17 events with data out of 348
+      total strong wind events (1976-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 4 events with
+      data out of 348 total strong wind events (1976-2013).'
+    - 'Observed health facilities destroyed or affected from strong wind (SNOWSTORM,
+      STORM) events in Colombia. DesInventar records: 5 events with data out of 348
+      total strong wind events (1976-2013).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (SNOWSTORM, STORM) events in Colombia. DesInventar records: 48 events with data
+      out of 348 total strong wind events (1976-2013).'
+    - 'Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM)
+      events in Colombia. DesInventar records: 94 events with data out of 348 total
+      strong wind events (1976-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 54 events with
+      data out of 348 total strong wind events (1976-2013).'
+    - 'Observed total economic losses in local currency from strong wind (SNOWSTORM,
+      STORM) events in Colombia. DesInventar records: 38 events with data out of 348
+      total strong wind events (1976-2013).'
+    - 'Observed total economic losses in US Dollars from strong wind (SNOWSTORM, STORM)
+      events in Colombia. DesInventar records: 1 events with data out of 348 total
+      strong wind events (1976-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (SNOWSTORM, STORM) events in Colombia. DesInventar records: 4 events with
+      data out of 348 total strong wind events (1976-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from strong wind
+      (SNOWSTORM, STORM) events in Colombia. DesInventar records: 41 events with data
+      out of 348 total strong wind events (1976-2013).'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (HURRICANE) events in Colombia. DesInventar records: 4 events
+      with data out of 7 total strong wind events (1963-1988).'
+    - 'Observed metres of transport networks destroyed from strong wind (HURRICANE)
+      events in Colombia. DesInventar records: 1 events with data out of 7 total strong
+      wind events (1963-1988).'
+    - 'Observed deaths directly caused by disaster events from strong wind (HURRICANE)
+      events in Colombia. DesInventar records: 3 events with data out of 7 total strong
+      wind events (1963-1988).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data
+      out of 7 total strong wind events (1963-1988).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (HURRICANE) events in Colombia. DesInventar records: 2 events with data out
+      of 7 total strong wind events (1963-1988).'
+    - 'Observed homes destroyed beyond habitability from strong wind (HURRICANE) events
+      in Colombia. DesInventar records: 5 events with data out of 7 total strong wind
+      events (1963-1988).'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (HURRICANE) events in Colombia. DesInventar records: 1 events with data
+      out of 7 total strong wind events (1963-1988).'
+    - 'Observed total economic losses in local currency from strong wind (HURRICANE)
+      events in Colombia. DesInventar records: 1 events with data out of 7 total strong
+      wind events (1963-1988).'
+    - 'Observed persons whose goods/services suffered serious damage from strong wind
+      (HURRICANE) events in Colombia. DesInventar records: 1 events with data out
+      of 7 total strong wind events (1963-1988).'
+    hazard_type: strong_wind
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from tsunami (TSUNAMI) events in Colombia. DesInventar records: 1 events with
+      data out of 5 total tsunami events (1979-1979).'
+    - 'Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events
+      in Colombia. DesInventar records: 4 events with data out of 5 total tsunami
+      events (1979-1979).'
+    - 'Observed health facilities destroyed or affected from tsunami (TSUNAMI) events
+      in Colombia. DesInventar records: 1 events with data out of 5 total tsunami
+      events (1979-1979).'
+    - 'Observed homes with non-structural damage, still habitable from tsunami (TSUNAMI)
+      events in Colombia. DesInventar records: 5 events with data out of 5 total tsunami
+      events (1979-1979).'
+    - 'Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events
+      in Colombia. DesInventar records: 3 events with data out of 5 total tsunami
+      events (1979-1979).'
+    - 'Observed persons injured or made sick directly by disaster events from tsunami
+      (TSUNAMI) events in Colombia. DesInventar records: 5 events with data out of
+      5 total tsunami events (1979-1979).'
+    - 'Observed persons missing or unaccounted for after disaster events from tsunami
+      (TSUNAMI) events in Colombia. DesInventar records: 3 events with data out of
+      5 total tsunami events (1979-1979).'
+    hazard_type: tsunami
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE) events in Colombia. DesInventar records: 893 events with
+      data out of 2,588 total wildfire events (1984-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE)
+      events in Colombia. DesInventar records: 10 events with data out of 2,588 total
+      wildfire events (1984-2013).'
+    - 'Observed metres of transport networks destroyed from wildfire (FIRE) events
+      in Colombia. DesInventar records: 1 events with data out of 2,588 total wildfire
+      events (1984-2013).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE) events
+      in Colombia. DesInventar records: 274 events with data out of 2,588 total wildfire
+      events (1984-2013).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE)
+      events in Colombia. DesInventar records: 27 events with data out of 2,588 total
+      wildfire events (1984-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from wildfire
+      (FIRE) events in Colombia. DesInventar records: 18 events with data out of 2,588
+      total wildfire events (1984-2013).'
+    - 'Observed health facilities destroyed or affected from wildfire (FIRE) events
+      in Colombia. DesInventar records: 14 events with data out of 2,588 total wildfire
+      events (1984-2013).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE)
+      events in Colombia. DesInventar records: 401 events with data out of 2,588 total
+      wildfire events (1984-2013).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE) events in
+      Colombia. DesInventar records: 922 events with data out of 2,588 total wildfire
+      events (1984-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE) events in Colombia. DesInventar records: 417 events with data out of
+      2,588 total wildfire events (1984-2013).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE) events
+      in Colombia. DesInventar records: 901 events with data out of 2,588 total wildfire
+      events (1984-2013).'
+    - 'Observed livestock lost from wildfire (FIRE) events in Colombia. DesInventar
+      records: 1 events with data out of 2,588 total wildfire events (1984-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from wildfire
+      (FIRE) events in Colombia. DesInventar records: 4 events with data out of 2,588
+      total wildfire events (1984-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE) events in Colombia. DesInventar records: 476 events with data out of
+      2,588 total wildfire events (1984-2013).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-criundrr_desinventar.md
+++ b/_datasets/rdls_lss-criundrr_desinventar.md
@@ -37,179 +37,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from coastal flood
-    (SURGE) events in Costa Rica. DesInventar records: 5 events with data out of 59
-    total coastal flood events (1970-2015)., Observed deaths directly caused by disaster
-    events from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records:
-    15 events with data out of 348 total earthquake events (1973-2012)., Observed
-    deaths directly caused by disaster events from flood (FLOOD) events in Costa Rica.
-    DesInventar records: 68 events with data out of 8,334 total flood events (1970-2016).,
-    Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
-    events in Costa Rica. DesInventar records: 85 events with data out of 3,596 total
-    landslide events (1970-2016)., Observed deaths directly caused by disaster events
-    from strong wind (STORM) events in Costa Rica. DesInventar records: 3 events with
-    data out of 14 total strong wind events (1995-2014)., Observed deaths directly
-    caused by disaster events from wildfire (FIRE) events in Costa Rica. DesInventar
-    records: 56 events with data out of 902 total wildfire events (1980-2013)., Observed
-    educational facilities destroyed or affected from earthquake (EARTHQUAKE) events
-    in Costa Rica. DesInventar records: 77 events with data out of 348 total earthquake
-    events (1973-2012)., Observed educational facilities destroyed or affected from
-    flood (FLOOD) events in Costa Rica. DesInventar records: 170 events with data
-    out of 8,334 total flood events (1970-2016)., Observed educational facilities
-    destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar
-    records: 33 events with data out of 3,596 total landslide events (1970-2016).,
-    Observed educational facilities destroyed or affected from wildfire (FIRE) events
-    in Costa Rica. DesInventar records: 12 events with data out of 902 total wildfire
-    events (1980-2013)., Observed health facilities destroyed or affected from earthquake
-    (EARTHQUAKE) events in Costa Rica. DesInventar records: 22 events with data out
-    of 348 total earthquake events (1973-2012)., Observed health facilities destroyed
-    or affected from flood (FLOOD) events in Costa Rica. DesInventar records: 25 events
-    with data out of 8,334 total flood events (1970-2016)., Observed health facilities
-    destroyed or affected from landslide (LANDSLIDE) events in Costa Rica. DesInventar
-    records: 3 events with data out of 3,596 total landslide events (1970-2016).,
-    Observed health facilities destroyed or affected from wildfire (FIRE) events in
-    Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire
-    events (1980-2013)., Observed hectares of crops/woods destroyed or affected from
-    drought (DROUGHT) events in Costa Rica. DesInventar records: 29 events with data
-    out of 438 total drought events (1972-2014)., Observed hectares of crops/woods
-    destroyed or affected from flood (FLOOD) events in Costa Rica. DesInventar records:
-    10 events with data out of 8,334 total flood events (1970-2016)., Observed hectares
-    of crops/woods destroyed or affected from landslide (LANDSLIDE) events in Costa
-    Rica. DesInventar records: 4 events with data out of 3,596 total landslide events
-    (1970-2016)., Observed homes destroyed beyond habitability from coastal flood
-    (SURGE) events in Costa Rica. DesInventar records: 6 events with data out of 59
-    total coastal flood events (1970-2015)., Observed homes destroyed beyond habitability
-    from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 132 events
-    with data out of 348 total earthquake events (1973-2012)., Observed homes destroyed
-    beyond habitability from flood (FLOOD) events in Costa Rica. DesInventar records:
-    220 events with data out of 8,334 total flood events (1970-2016)., Observed homes
-    destroyed beyond habitability from landslide (LANDSLIDE) events in Costa Rica.
-    DesInventar records: 154 events with data out of 3,596 total landslide events
-    (1970-2016)., Observed homes destroyed beyond habitability from strong wind (STORM)
-    events in Costa Rica. DesInventar records: 2 events with data out of 14 total
-    strong wind events (1995-2014)., Observed homes destroyed beyond habitability
-    from wildfire (FIRE) events in Costa Rica. DesInventar records: 463 events with
-    data out of 902 total wildfire events (1980-2013)., Observed homes with non-structural
-    damage, still habitable from coastal flood (SURGE) events in Costa Rica. DesInventar
-    records: 22 events with data out of 59 total coastal flood events (1970-2015).,
-    Observed homes with non-structural damage, still habitable from convective storm
-    (HAILSTORM) events in Costa Rica. DesInventar records: 2 events with data out
-    of 2 total convective storm events (1993-2012)., Observed homes with non-structural
-    damage, still habitable from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar
-    records: 148 events with data out of 348 total earthquake events (1973-2012).,
-    Observed homes with non-structural damage, still habitable from flood (FLOOD)
-    events in Costa Rica. DesInventar records: 3,716 events with data out of 8,334
-    total flood events (1970-2016)., Observed homes with non-structural damage, still
-    habitable from landslide (LANDSLIDE) events in Costa Rica. DesInventar records:
-    1,402 events with data out of 3,596 total landslide events (1970-2016)., Observed
-    homes with non-structural damage, still habitable from strong wind (STORM) events
-    in Costa Rica. DesInventar records: 12 events with data out of 14 total strong
-    wind events (1995-2014)., Observed homes with non-structural damage, still habitable
-    from wildfire (FIRE) events in Costa Rica. DesInventar records: 202 events with
-    data out of 902 total wildfire events (1980-2013)., Observed livestock lost from
-    drought (DROUGHT) events in Costa Rica. DesInventar records: 1 events with data
-    out of 438 total drought events (1972-2014)., Observed livestock lost from earthquake
-    (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events with data out
-    of 348 total earthquake events (1973-2012)., Observed livestock lost from landslide
-    (LANDSLIDE) events in Costa Rica. DesInventar records: 2 events with data out
-    of 3,596 total landslide events (1970-2016)., Observed metres of transport networks
-    destroyed from coastal flood (SURGE) events in Costa Rica. DesInventar records:
-    2 events with data out of 59 total coastal flood events (1970-2015)., Observed
-    metres of transport networks destroyed from flood (FLOOD) events in Costa Rica.
-    DesInventar records: 49 events with data out of 8,334 total flood events (1970-2016).,
-    Observed metres of transport networks destroyed from landslide (LANDSLIDE) events
-    in Costa Rica. DesInventar records: 212 events with data out of 3,596 total landslide
-    events (1970-2016)., Observed persons indirectly affected (disruption to services,
-    commerce, work) from coastal flood (SURGE) events in Costa Rica. DesInventar records:
-    1 events with data out of 59 total coastal flood events (1970-2015)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from flood
-    (FLOOD) events in Costa Rica. DesInventar records: 105 events with data out of
-    8,334 total flood events (1970-2016)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from landslide (LANDSLIDE) events in Costa Rica.
-    DesInventar records: 44 events with data out of 3,596 total landslide events (1970-2016).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from wildfire (FIRE) events in Costa Rica. DesInventar records: 10 events with
-    data out of 902 total wildfire events (1980-2013)., Observed persons injured or
-    made sick directly by disaster events from coastal flood (SURGE) events in Costa
-    Rica. DesInventar records: 2 events with data out of 59 total coastal flood events
-    (1970-2015)., Observed persons injured or made sick directly by disaster events
-    from flood (FLOOD) events in Costa Rica. DesInventar records: 10 events with data
-    out of 8,334 total flood events (1970-2016)., Observed persons injured or made
-    sick directly by disaster events from landslide (LANDSLIDE) events in Costa Rica.
-    DesInventar records: 14 events with data out of 3,596 total landslide events (1970-2016).,
-    Observed persons injured or made sick directly by disaster events from wildfire
-    (FIRE) events in Costa Rica. DesInventar records: 1 events with data out of 902
-    total wildfire events (1980-2013)., Observed persons missing or unaccounted for
-    after disaster events from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar
-    records: 1 events with data out of 348 total earthquake events (1973-2012)., Observed
-    persons missing or unaccounted for after disaster events from flood (FLOOD) events
-    in Costa Rica. DesInventar records: 13 events with data out of 8,334 total flood
-    events (1970-2016)., Observed persons missing or unaccounted for after disaster
-    events from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 7
-    events with data out of 3,596 total landslide events (1970-2016)., Observed persons
-    permanently relocated from homes from earthquake (EARTHQUAKE) events in Costa
-    Rica. DesInventar records: 2 events with data out of 348 total earthquake events
-    (1973-2012)., Observed persons permanently relocated from homes from flood (FLOOD)
-    events in Costa Rica. DesInventar records: 19 events with data out of 8,334 total
-    flood events (1970-2016)., Observed persons permanently relocated from homes from
-    landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 7 events with
-    data out of 3,596 total landslide events (1970-2016)., Observed persons permanently
-    relocated from homes from wildfire (FIRE) events in Costa Rica. DesInventar records:
-    1 events with data out of 902 total wildfire events (1980-2013)., Observed persons
-    temporarily evacuated from homes or workplaces from coastal flood (SURGE) events
-    in Costa Rica. DesInventar records: 3 events with data out of 59 total coastal
-    flood events (1970-2015)., Observed persons temporarily evacuated from homes or
-    workplaces from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records:
-    10 events with data out of 348 total earthquake events (1973-2012)., Observed
-    persons temporarily evacuated from homes or workplaces from flood (FLOOD) events
-    in Costa Rica. DesInventar records: 795 events with data out of 8,334 total flood
-    events (1970-2016)., Observed persons temporarily evacuated from homes or workplaces
-    from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 106 events
-    with data out of 3,596 total landslide events (1970-2016)., Observed persons whose
-    goods/services suffered serious damage from coastal flood (SURGE) events in Costa
-    Rica. DesInventar records: 17 events with data out of 59 total coastal flood events
-    (1970-2015)., Observed persons whose goods/services suffered serious damage from
-    convective storm (HAILSTORM) events in Costa Rica. DesInventar records: 1 events
-    with data out of 2 total convective storm events (1993-2012)., Observed persons
-    whose goods/services suffered serious damage from drought (DROUGHT) events in
-    Costa Rica. DesInventar records: 22 events with data out of 438 total drought
-    events (1972-2014)., Observed persons whose goods/services suffered serious damage
-    from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 150 events
-    with data out of 348 total earthquake events (1973-2012)., Observed persons whose
-    goods/services suffered serious damage from flood (FLOOD) events in Costa Rica.
-    DesInventar records: 2,394 events with data out of 8,334 total flood events (1970-2016).,
-    Observed persons whose goods/services suffered serious damage from landslide (LANDSLIDE)
-    events in Costa Rica. DesInventar records: 680 events with data out of 3,596 total
-    landslide events (1970-2016)., Observed persons whose goods/services suffered
-    serious damage from strong wind (STORM) events in Costa Rica. DesInventar records:
-    10 events with data out of 14 total strong wind events (1995-2014)., Observed
-    persons whose goods/services suffered serious damage from wildfire (FIRE) events
-    in Costa Rica. DesInventar records: 172 events with data out of 902 total wildfire
-    events (1980-2013)., Observed total economic losses in US Dollars from drought
-    (DROUGHT) events in Costa Rica. DesInventar records: 18 events with data out of
-    438 total drought events (1972-2014)., Observed total economic losses in US Dollars
-    from earthquake (EARTHQUAKE) events in Costa Rica. DesInventar records: 2 events
-    with data out of 348 total earthquake events (1973-2012)., Observed total economic
-    losses in US Dollars from flood (FLOOD) events in Costa Rica. DesInventar records:
-    4 events with data out of 8,334 total flood events (1970-2016)., Observed total
-    economic losses in US Dollars from landslide (LANDSLIDE) events in Costa Rica.
-    DesInventar records: 8 events with data out of 3,596 total landslide events (1970-2016).,
-    Observed total economic losses in US Dollars from wildfire (FIRE) events in Costa
-    Rica. DesInventar records: 229 events with data out of 902 total wildfire events
-    (1980-2013)., Observed total economic losses in local currency from coastal flood
-    (SURGE) events in Costa Rica. DesInventar records: 1 events with data out of 59
-    total coastal flood events (1970-2015)., Observed total economic losses in local
-    currency from drought (DROUGHT) events in Costa Rica. DesInventar records: 25
-    events with data out of 438 total drought events (1972-2014)., Observed total
-    economic losses in local currency from earthquake (EARTHQUAKE) events in Costa
-    Rica. DesInventar records: 6 events with data out of 348 total earthquake events
-    (1973-2012)., Observed total economic losses in local currency from flood (FLOOD)
-    events in Costa Rica. DesInventar records: 25 events with data out of 8,334 total
-    flood events (1970-2016)., Observed total economic losses in local currency from
-    landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 24 events with
-    data out of 3,596 total landslide events (1970-2016)., Observed total economic
-    losses in local currency from wildfire (FIRE) events in Costa Rica. DesInventar
-    records: 242 events with data out of 902 total wildfire events (1980-2013).'
+  description: 74 loss records across 8 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -221,6 +49,251 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 74
+  loss_groups:
+  - count: 9
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from coastal flood (SURGE) events in Costa Rica. DesInventar records: 1 events
+      with data out of 59 total coastal flood events (1970-2015).'
+    - 'Observed metres of transport networks destroyed from coastal flood (SURGE)
+      events in Costa Rica. DesInventar records: 2 events with data out of 59 total
+      coastal flood events (1970-2015).'
+    - 'Observed deaths directly caused by disaster events from coastal flood (SURGE)
+      events in Costa Rica. DesInventar records: 5 events with data out of 59 total
+      coastal flood events (1970-2015).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from coastal
+      flood (SURGE) events in Costa Rica. DesInventar records: 3 events with data
+      out of 59 total coastal flood events (1970-2015).'
+    - 'Observed homes with non-structural damage, still habitable from coastal flood
+      (SURGE) events in Costa Rica. DesInventar records: 22 events with data out of
+      59 total coastal flood events (1970-2015).'
+    - 'Observed homes destroyed beyond habitability from coastal flood (SURGE) events
+      in Costa Rica. DesInventar records: 6 events with data out of 59 total coastal
+      flood events (1970-2015).'
+    - 'Observed persons injured or made sick directly by disaster events from coastal
+      flood (SURGE) events in Costa Rica. DesInventar records: 2 events with data
+      out of 59 total coastal flood events (1970-2015).'
+    - 'Observed total economic losses in local currency from coastal flood (SURGE)
+      events in Costa Rica. DesInventar records: 1 events with data out of 59 total
+      coastal flood events (1970-2015).'
+    - 'Observed persons whose goods/services suffered serious damage from coastal
+      flood (SURGE) events in Costa Rica. DesInventar records: 17 events with data
+      out of 59 total coastal flood events (1970-2015).'
+    hazard_type: coastal_flood
+  - count: 2
+    descriptions:
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (HAILSTORM) events in Costa Rica. DesInventar records: 2 events with data
+      out of 2 total convective storm events (1993-2012).'
+    - 'Observed persons whose goods/services suffered serious damage from convective
+      storm (HAILSTORM) events in Costa Rica. DesInventar records: 1 events with data
+      out of 2 total convective storm events (1993-2012).'
+    hazard_type: convective_storm
+  - count: 5
+    descriptions:
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Costa Rica. DesInventar records: 29 events with data out of 438 total
+      drought events (1972-2014).'
+    - 'Observed total economic losses in local currency from drought (DROUGHT) events
+      in Costa Rica. DesInventar records: 25 events with data out of 438 total drought
+      events (1972-2014).'
+    - 'Observed total economic losses in US Dollars from drought (DROUGHT) events
+      in Costa Rica. DesInventar records: 18 events with data out of 438 total drought
+      events (1972-2014).'
+    - 'Observed livestock lost from drought (DROUGHT) events in Costa Rica. DesInventar
+      records: 1 events with data out of 438 total drought events (1972-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (DROUGHT) events in Costa Rica. DesInventar records: 22 events with data out
+      of 438 total drought events (1972-2014).'
+    hazard_type: drought
+  - count: 12
+    descriptions:
+    - 'Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE)
+      events in Costa Rica. DesInventar records: 15 events with data out of 348 total
+      earthquake events (1973-2012).'
+    - 'Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Costa Rica. DesInventar records: 77 events with data out of 348 total
+      earthquake events (1973-2012).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from earthquake
+      (EARTHQUAKE) events in Costa Rica. DesInventar records: 10 events with data
+      out of 348 total earthquake events (1973-2012).'
+    - 'Observed health facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Costa Rica. DesInventar records: 22 events with data out of 348 total
+      earthquake events (1973-2012).'
+    - 'Observed homes with non-structural damage, still habitable from earthquake
+      (EARTHQUAKE) events in Costa Rica. DesInventar records: 148 events with data
+      out of 348 total earthquake events (1973-2012).'
+    - 'Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events
+      in Costa Rica. DesInventar records: 132 events with data out of 348 total earthquake
+      events (1973-2012).'
+    - 'Observed total economic losses in local currency from earthquake (EARTHQUAKE)
+      events in Costa Rica. DesInventar records: 6 events with data out of 348 total
+      earthquake events (1973-2012).'
+    - 'Observed total economic losses in US Dollars from earthquake (EARTHQUAKE) events
+      in Costa Rica. DesInventar records: 2 events with data out of 348 total earthquake
+      events (1973-2012).'
+    - 'Observed livestock lost from earthquake (EARTHQUAKE) events in Costa Rica.
+      DesInventar records: 2 events with data out of 348 total earthquake events (1973-2012).'
+    - 'Observed persons missing or unaccounted for after disaster events from earthquake
+      (EARTHQUAKE) events in Costa Rica. DesInventar records: 1 events with data out
+      of 348 total earthquake events (1973-2012).'
+    - 'Observed persons permanently relocated from homes from earthquake (EARTHQUAKE)
+      events in Costa Rica. DesInventar records: 2 events with data out of 348 total
+      earthquake events (1973-2012).'
+    - 'Observed persons whose goods/services suffered serious damage from earthquake
+      (EARTHQUAKE) events in Costa Rica. DesInventar records: 150 events with data
+      out of 348 total earthquake events (1973-2012).'
+    hazard_type: earthquake
+  - count: 15
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Costa Rica. DesInventar records: 105 events with
+      data out of 8,334 total flood events (1970-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Costa Rica. DesInventar records: 10 events with data out of 8,334 total flood
+      events (1970-2016).'
+    - 'Observed metres of transport networks destroyed from flood (FLOOD) events in
+      Costa Rica. DesInventar records: 49 events with data out of 8,334 total flood
+      events (1970-2016).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Costa Rica. DesInventar records: 68 events with data out of 8,334 total flood
+      events (1970-2016).'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Costa Rica. DesInventar records: 170 events with data out of 8,334 total
+      flood events (1970-2016).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLOOD) events in Costa Rica. DesInventar records: 795 events with data out
+      of 8,334 total flood events (1970-2016).'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Costa Rica. DesInventar records: 25 events with data out of 8,334 total flood
+      events (1970-2016).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Costa Rica. DesInventar records: 3,716 events with data out of 8,334
+      total flood events (1970-2016).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Costa
+      Rica. DesInventar records: 220 events with data out of 8,334 total flood events
+      (1970-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Costa Rica. DesInventar records: 10 events with data out of
+      8,334 total flood events (1970-2016).'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Costa Rica. DesInventar records: 25 events with data out of 8,334 total flood
+      events (1970-2016).'
+    - 'Observed total economic losses in US Dollars from flood (FLOOD) events in Costa
+      Rica. DesInventar records: 4 events with data out of 8,334 total flood events
+      (1970-2016).'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLOOD) events in Costa Rica. DesInventar records: 13 events with data out of
+      8,334 total flood events (1970-2016).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Costa Rica. DesInventar records: 19 events with data out of 8,334 total flood
+      events (1970-2016).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Costa Rica. DesInventar records: 2,394 events with data out of 8,334
+      total flood events (1970-2016).'
+    hazard_type: flood
+  - count: 16
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (LANDSLIDE) events in Costa Rica. DesInventar records: 44 events
+      with data out of 3,596 total landslide events (1970-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 4 events with data out of 3,596 total
+      landslide events (1970-2016).'
+    - 'Observed metres of transport networks destroyed from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 212 events with data out of 3,596
+      total landslide events (1970-2016).'
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 85 events with data out of 3,596
+      total landslide events (1970-2016).'
+    - 'Observed educational facilities destroyed or affected from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 33 events with data out of 3,596
+      total landslide events (1970-2016).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from landslide
+      (LANDSLIDE) events in Costa Rica. DesInventar records: 106 events with data
+      out of 3,596 total landslide events (1970-2016).'
+    - 'Observed health facilities destroyed or affected from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 3 events with data out of 3,596 total
+      landslide events (1970-2016).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 1,402 events with data out of 3,596
+      total landslide events (1970-2016).'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Costa Rica. DesInventar records: 154 events with data out of 3,596 total
+      landslide events (1970-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (LANDSLIDE) events in Costa Rica. DesInventar records: 14 events with data out
+      of 3,596 total landslide events (1970-2016).'
+    - 'Observed total economic losses in local currency from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 24 events with data out of 3,596
+      total landslide events (1970-2016).'
+    - 'Observed total economic losses in US Dollars from landslide (LANDSLIDE) events
+      in Costa Rica. DesInventar records: 8 events with data out of 3,596 total landslide
+      events (1970-2016).'
+    - 'Observed livestock lost from landslide (LANDSLIDE) events in Costa Rica. DesInventar
+      records: 2 events with data out of 3,596 total landslide events (1970-2016).'
+    - 'Observed persons missing or unaccounted for after disaster events from landslide
+      (LANDSLIDE) events in Costa Rica. DesInventar records: 7 events with data out
+      of 3,596 total landslide events (1970-2016).'
+    - 'Observed persons permanently relocated from homes from landslide (LANDSLIDE)
+      events in Costa Rica. DesInventar records: 7 events with data out of 3,596 total
+      landslide events (1970-2016).'
+    - 'Observed persons whose goods/services suffered serious damage from landslide
+      (LANDSLIDE) events in Costa Rica. DesInventar records: 680 events with data
+      out of 3,596 total landslide events (1970-2016).'
+    hazard_type: landslide
+  - count: 4
+    descriptions:
+    - 'Observed deaths directly caused by disaster events from strong wind (STORM)
+      events in Costa Rica. DesInventar records: 3 events with data out of 14 total
+      strong wind events (1995-2014).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (STORM) events in Costa Rica. DesInventar records: 12 events with data out of
+      14 total strong wind events (1995-2014).'
+    - 'Observed homes destroyed beyond habitability from strong wind (STORM) events
+      in Costa Rica. DesInventar records: 2 events with data out of 14 total strong
+      wind events (1995-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from strong wind
+      (STORM) events in Costa Rica. DesInventar records: 10 events with data out of
+      14 total strong wind events (1995-2014).'
+    hazard_type: strong_wind
+  - count: 11
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE) events in Costa Rica. DesInventar records: 10 events with
+      data out of 902 total wildfire events (1980-2013).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE) events
+      in Costa Rica. DesInventar records: 56 events with data out of 902 total wildfire
+      events (1980-2013).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE)
+      events in Costa Rica. DesInventar records: 12 events with data out of 902 total
+      wildfire events (1980-2013).'
+    - 'Observed health facilities destroyed or affected from wildfire (FIRE) events
+      in Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire
+      events (1980-2013).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE)
+      events in Costa Rica. DesInventar records: 202 events with data out of 902 total
+      wildfire events (1980-2013).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE) events in
+      Costa Rica. DesInventar records: 463 events with data out of 902 total wildfire
+      events (1980-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE) events in Costa Rica. DesInventar records: 1 events with data out of
+      902 total wildfire events (1980-2013).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE) events
+      in Costa Rica. DesInventar records: 242 events with data out of 902 total wildfire
+      events (1980-2013).'
+    - 'Observed total economic losses in US Dollars from wildfire (FIRE) events in
+      Costa Rica. DesInventar records: 229 events with data out of 902 total wildfire
+      events (1980-2013).'
+    - 'Observed persons permanently relocated from homes from wildfire (FIRE) events
+      in Costa Rica. DesInventar records: 1 events with data out of 902 total wildfire
+      events (1980-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE) events in Costa Rica. DesInventar records: 172 events with data out of
+      902 total wildfire events (1980-2013).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-ethundrr_desinventar.md
+++ b/_datasets/rdls_lss-ethundrr_desinventar.md
@@ -36,116 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from convective
-    storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 17 events
-    with data out of 242 total convective storm events (1996-2012)., Observed deaths
-    directly caused by disaster events from drought (DROUGHT) events in Ethiopia.
-    DesInventar records: 2 events with data out of 5,802 total drought events (1992-2013).,
-    Observed deaths directly caused by disaster events from flood (FLOOD) events in
-    Ethiopia. DesInventar records: 179 events with data out of 1,475 total flood events
-    (2006-2013)., Observed deaths directly caused by disaster events from landslide
-    (LANDSLIDE) events in Ethiopia. DesInventar records: 30 events with data out of
-    141 total landslide events (2001-2013)., Observed deaths directly caused by disaster
-    events from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar
-    records: 2 events with data out of 27 total strong wind events (1996-2009)., Observed
-    deaths directly caused by disaster events from wildfire (FIRE, FOREST FIRE) events
-    in Ethiopia. DesInventar records: 76 events with data out of 1,410 total wildfire
-    events (2000-2013)., Observed educational facilities destroyed or affected from
-    flood (FLOOD) events in Ethiopia. DesInventar records: 4 events with data out
-    of 1,475 total flood events (2006-2013)., Observed health facilities destroyed
-    or affected from flood (FLOOD) events in Ethiopia. DesInventar records: 1 events
-    with data out of 1,475 total flood events (2006-2013)., Observed hectares of crops/woods
-    destroyed or affected from convective storm (HAILSTORM, THUNDERSTORM) events in
-    Ethiopia. DesInventar records: 141 events with data out of 242 total convective
-    storm events (1996-2012)., Observed hectares of crops/woods destroyed or affected
-    from drought (DROUGHT) events in Ethiopia. DesInventar records: 75 events with
-    data out of 5,802 total drought events (1992-2013)., Observed hectares of crops/woods
-    destroyed or affected from extreme temperature (FROST) events in Ethiopia. DesInventar
-    records: 6 events with data out of 7 total extreme temperature events (1999-2005).,
-    Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
-    in Ethiopia. DesInventar records: 392 events with data out of 1,475 total flood
-    events (2006-2013)., Observed hectares of crops/woods destroyed or affected from
-    landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 55 events with
-    data out of 141 total landslide events (2001-2013)., Observed hectares of crops/woods
-    destroyed or affected from strong wind (SNOWSTORM, STORM, WINDSTORM) events in
-    Ethiopia. DesInventar records: 5 events with data out of 27 total strong wind
-    events (1996-2009)., Observed hectares of crops/woods destroyed or affected from
-    wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 60 events
-    with data out of 1,410 total wildfire events (2000-2013)., Observed homes destroyed
-    beyond habitability from convective storm (HAILSTORM, THUNDERSTORM) events in
-    Ethiopia. DesInventar records: 27 events with data out of 242 total convective
-    storm events (1996-2012)., Observed homes destroyed beyond habitability from earthquake
-    (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of
-    3 total earthquake events (1993-2005)., Observed homes destroyed beyond habitability
-    from flood (FLOOD) events in Ethiopia. DesInventar records: 141 events with data
-    out of 1,475 total flood events (2006-2013)., Observed homes destroyed beyond
-    habitability from landslide (LANDSLIDE) events in Ethiopia. DesInventar records:
-    26 events with data out of 141 total landslide events (2001-2013)., Observed homes
-    destroyed beyond habitability from strong wind (SNOWSTORM, STORM, WINDSTORM) events
-    in Ethiopia. DesInventar records: 5 events with data out of 27 total strong wind
-    events (1996-2009)., Observed homes destroyed beyond habitability from wildfire
-    (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 89 events with data
-    out of 1,410 total wildfire events (2000-2013)., Observed homes with non-structural
-    damage, still habitable from convective storm (HAILSTORM, THUNDERSTORM) events
-    in Ethiopia. DesInventar records: 1 events with data out of 242 total convective
-    storm events (1996-2012)., Observed homes with non-structural damage, still habitable
-    from flood (FLOOD) events in Ethiopia. DesInventar records: 31 events with data
-    out of 1,475 total flood events (2006-2013)., Observed homes with non-structural
-    damage, still habitable from landslide (LANDSLIDE) events in Ethiopia. DesInventar
-    records: 2 events with data out of 141 total landslide events (2001-2013)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from convective
-    storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 30 events
-    with data out of 242 total convective storm events (1996-2012)., Observed persons
-    indirectly affected (disruption to services, commerce, work) from drought (DROUGHT)
-    events in Ethiopia. DesInventar records: 5,569 events with data out of 5,802 total
-    drought events (1992-2013)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from earthquake (EARTHQUAKE) events in Ethiopia.
-    DesInventar records: 1 events with data out of 3 total earthquake events (1993-2005).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from extreme temperature (FROST) events in Ethiopia. DesInventar records: 2 events
-    with data out of 7 total extreme temperature events (1999-2005)., Observed persons
-    indirectly affected (disruption to services, commerce, work) from extreme temperature
-    (HEAT WAVE) events in Ethiopia. DesInventar records: 1 events with data out of
-    2 total extreme temperature events (1996-1996)., Observed persons indirectly affected
-    (disruption to services, commerce, work) from flood (FLOOD) events in Ethiopia.
-    DesInventar records: 926 events with data out of 1,475 total flood events (2006-2013).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 54 events
-    with data out of 141 total landslide events (2001-2013)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from strong wind (SNOWSTORM,
-    STORM, WINDSTORM) events in Ethiopia. DesInventar records: 12 events with data
-    out of 27 total strong wind events (1996-2009)., Observed persons indirectly affected
-    (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events
-    in Ethiopia. DesInventar records: 239 events with data out of 1,410 total wildfire
-    events (2000-2013)., Observed persons injured or made sick directly by disaster
-    events from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar
-    records: 5 events with data out of 242 total convective storm events (1996-2012).,
-    Observed persons injured or made sick directly by disaster events from earthquake
-    (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out of
-    3 total earthquake events (1993-2005)., Observed persons injured or made sick
-    directly by disaster events from flood (FLOOD) events in Ethiopia. DesInventar
-    records: 27 events with data out of 1,475 total flood events (2006-2013)., Observed
-    persons injured or made sick directly by disaster events from landslide (LANDSLIDE)
-    events in Ethiopia. DesInventar records: 9 events with data out of 141 total landslide
-    events (2001-2013)., Observed persons injured or made sick directly by disaster
-    events from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records:
-    59 events with data out of 1,410 total wildfire events (2000-2013)., Observed
-    persons permanently relocated from homes from convective storm (HAILSTORM, THUNDERSTORM)
-    events in Ethiopia. DesInventar records: 13 events with data out of 242 total
-    convective storm events (1996-2012)., Observed persons permanently relocated from
-    homes from drought (DROUGHT) events in Ethiopia. DesInventar records: 7 events
-    with data out of 5,802 total drought events (1992-2013)., Observed persons permanently
-    relocated from homes from flood (FLOOD) events in Ethiopia. DesInventar records:
-    274 events with data out of 1,475 total flood events (2006-2013)., Observed persons
-    permanently relocated from homes from landslide (LANDSLIDE) events in Ethiopia.
-    DesInventar records: 33 events with data out of 141 total landslide events (2001-2013).,
-    Observed persons permanently relocated from homes from wildfire (FIRE, FOREST
-    FIRE) events in Ethiopia. DesInventar records: 34 events with data out of 1,410
-    total wildfire events (2000-2013)., Observed total economic losses in local currency
-    from flood (FLOOD) events in Ethiopia. DesInventar records: 3 events with data
-    out of 1,475 total flood events (2006-2013)., Observed total economic losses in
-    local currency from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar
-    records: 570 events with data out of 1,410 total wildfire events (2000-2013).'
+  description: 45 loss records across 8 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -157,6 +48,166 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 45
+  loss_groups:
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from convective storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar
+      records: 30 events with data out of 242 total convective storm events (1996-2012).'
+    - 'Observed hectares of crops/woods destroyed or affected from convective storm
+      (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 141 events
+      with data out of 242 total convective storm events (1996-2012).'
+    - 'Observed deaths directly caused by disaster events from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Ethiopia. DesInventar records: 17 events with data out
+      of 242 total convective storm events (1996-2012).'
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 1 events
+      with data out of 242 total convective storm events (1996-2012).'
+    - 'Observed homes destroyed beyond habitability from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Ethiopia. DesInventar records: 27 events with data out
+      of 242 total convective storm events (1996-2012).'
+    - 'Observed persons injured or made sick directly by disaster events from convective
+      storm (HAILSTORM, THUNDERSTORM) events in Ethiopia. DesInventar records: 5 events
+      with data out of 242 total convective storm events (1996-2012).'
+    - 'Observed persons permanently relocated from homes from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Ethiopia. DesInventar records: 13 events with data out
+      of 242 total convective storm events (1996-2012).'
+    hazard_type: convective_storm
+  - count: 4
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Ethiopia. DesInventar records: 5,569 events
+      with data out of 5,802 total drought events (1992-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Ethiopia. DesInventar records: 75 events with data out of 5,802 total
+      drought events (1992-2013).'
+    - 'Observed deaths directly caused by disaster events from drought (DROUGHT) events
+      in Ethiopia. DesInventar records: 2 events with data out of 5,802 total drought
+      events (1992-2013).'
+    - 'Observed persons permanently relocated from homes from drought (DROUGHT) events
+      in Ethiopia. DesInventar records: 7 events with data out of 5,802 total drought
+      events (1992-2013).'
+    hazard_type: drought
+  - count: 3
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from earthquake (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events
+      with data out of 3 total earthquake events (1993-2005).'
+    - 'Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events
+      in Ethiopia. DesInventar records: 1 events with data out of 3 total earthquake
+      events (1993-2005).'
+    - 'Observed persons injured or made sick directly by disaster events from earthquake
+      (EARTHQUAKE) events in Ethiopia. DesInventar records: 1 events with data out
+      of 3 total earthquake events (1993-2005).'
+    hazard_type: earthquake
+  - count: 3
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from extreme temperature (FROST) events in Ethiopia. DesInventar records: 2
+      events with data out of 7 total extreme temperature events (1999-2005).'
+    - 'Observed hectares of crops/woods destroyed or affected from extreme temperature
+      (FROST) events in Ethiopia. DesInventar records: 6 events with data out of 7
+      total extreme temperature events (1999-2005).'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from extreme temperature (HEAT WAVE) events in Ethiopia. DesInventar records:
+      1 events with data out of 2 total extreme temperature events (1996-1996).'
+    hazard_type: extreme_temperature
+  - count: 10
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Ethiopia. DesInventar records: 926 events with
+      data out of 1,475 total flood events (2006-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Ethiopia. DesInventar records: 392 events with data out of 1,475 total flood
+      events (2006-2013).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Ethiopia. DesInventar records: 179 events with data out of 1,475 total flood
+      events (2006-2013).'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Ethiopia. DesInventar records: 4 events with data out of 1,475 total flood
+      events (2006-2013).'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Ethiopia. DesInventar records: 1 events with data out of 1,475 total flood
+      events (2006-2013).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Ethiopia. DesInventar records: 31 events with data out of 1,475 total
+      flood events (2006-2013).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Ethiopia.
+      DesInventar records: 141 events with data out of 1,475 total flood events (2006-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Ethiopia. DesInventar records: 27 events with data out of
+      1,475 total flood events (2006-2013).'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Ethiopia. DesInventar records: 3 events with data out of 1,475 total flood
+      events (2006-2013).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Ethiopia. DesInventar records: 274 events with data out of 1,475 total flood
+      events (2006-2013).'
+    hazard_type: flood
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (LANDSLIDE) events in Ethiopia. DesInventar records: 54 events
+      with data out of 141 total landslide events (2001-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
+      events in Ethiopia. DesInventar records: 55 events with data out of 141 total
+      landslide events (2001-2013).'
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Ethiopia. DesInventar records: 30 events with data out of 141 total
+      landslide events (2001-2013).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+      events in Ethiopia. DesInventar records: 2 events with data out of 141 total
+      landslide events (2001-2013).'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Ethiopia. DesInventar records: 26 events with data out of 141 total landslide
+      events (2001-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (LANDSLIDE) events in Ethiopia. DesInventar records: 9 events with data out
+      of 141 total landslide events (2001-2013).'
+    - 'Observed persons permanently relocated from homes from landslide (LANDSLIDE)
+      events in Ethiopia. DesInventar records: 33 events with data out of 141 total
+      landslide events (2001-2013).'
+    hazard_type: landslide
+  - count: 4
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (SNOWSTORM, STORM, WINDSTORM) events in Ethiopia. DesInventar
+      records: 12 events with data out of 27 total strong wind events (1996-2009).'
+    - 'Observed hectares of crops/woods destroyed or affected from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Ethiopia. DesInventar records: 5 events with data
+      out of 27 total strong wind events (1996-2009).'
+    - 'Observed deaths directly caused by disaster events from strong wind (SNOWSTORM,
+      STORM, WINDSTORM) events in Ethiopia. DesInventar records: 2 events with data
+      out of 27 total strong wind events (1996-2009).'
+    - 'Observed homes destroyed beyond habitability from strong wind (SNOWSTORM, STORM,
+      WINDSTORM) events in Ethiopia. DesInventar records: 5 events with data out of
+      27 total strong wind events (1996-2009).'
+    hazard_type: strong_wind
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 239
+      events with data out of 1,410 total wildfire events (2000-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Ethiopia. DesInventar records: 60 events with data out
+      of 1,410 total wildfire events (2000-2013).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Ethiopia. DesInventar records: 76 events with data out of 1,410
+      total wildfire events (2000-2013).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Ethiopia. DesInventar records: 89 events with data out of 1,410 total
+      wildfire events (2000-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Ethiopia. DesInventar records: 59 events with
+      data out of 1,410 total wildfire events (2000-2013).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Ethiopia. DesInventar records: 570 events with data out of 1,410
+      total wildfire events (2000-2013).'
+    - 'Observed persons permanently relocated from homes from wildfire (FIRE, FOREST
+      FIRE) events in Ethiopia. DesInventar records: 34 events with data out of 1,410
+      total wildfire events (2000-2013).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-hdx_internal_displacemen_bfa_idmc_event_data_for_bfa_flood.md
+++ b/_datasets/rdls_lss-hdx_internal_displacemen_bfa_idmc_event_data_for_bfa_flood.md
@@ -88,7 +88,7 @@ hazard:
   occurrence_range: ''
   processes: fluvial_flood
   seasonality: ''
-license: CC-BY-IGO-3.0
+license: Creative Commons Attribution for Intergovernmental Organisations (CC BY-IGO)
 loss:
   approach: ''
   base_data_type: ''
@@ -104,6 +104,13 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 1
+  loss_groups:
+  - count: 1
+    descriptions:
+    - 'Loss data from HDX dataset: Burkina Faso - Internal Displacements Updates (IDU)
+      (event data)'
+    hazard_type: flood
   type: ''
   vulnerability_id: ''
 project: null

--- a/_datasets/rdls_lss-idnundrr_desinventar.md
+++ b/_datasets/rdls_lss-idnundrr_desinventar.md
@@ -36,118 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from coastal flood
-    (SURGE) events in Indonesia. DesInventar records: 17 events with data out of 270
-    total coastal flood events (2009-2011)., Observed deaths directly caused by disaster
-    events from drought (DROUGHT) events in Indonesia. DesInventar records: 1 events
-    with data out of 1,748 total drought events (2004-2008)., Observed deaths directly
-    caused by disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
-    records: 165 events with data out of 449 total earthquake events (1976-2004).,
-    Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events
-    in Indonesia. DesInventar records: 11 events with data out of 13 total tsunami
-    events (1973-1977)., Observed deaths directly caused by disaster events from wildfire
-    (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 145 events with
-    data out of 2,827 total wildfire events (2005-2012)., Observed educational facilities
-    destroyed or affected from coastal flood (SURGE) events in Indonesia. DesInventar
-    records: 11 events with data out of 270 total coastal flood events (2009-2011).,
-    Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE)
-    events in Indonesia. DesInventar records: 171 events with data out of 449 total
-    earthquake events (1976-2004)., Observed educational facilities destroyed or affected
-    from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 2 events with
-    data out of 13 total tsunami events (1973-1977)., Observed educational facilities
-    destroyed or affected from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar
-    records: 50 events with data out of 2,827 total wildfire events (2005-2012).,
-    Observed health facilities destroyed or affected from coastal flood (SURGE) events
-    in Indonesia. DesInventar records: 6 events with data out of 270 total coastal
-    flood events (2009-2011)., Observed health facilities destroyed or affected from
-    earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 83 events with
-    data out of 449 total earthquake events (1976-2004)., Observed health facilities
-    destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar
-    records: 1 events with data out of 13 total tsunami events (1973-1977)., Observed
-    health facilities destroyed or affected from wildfire (FIRE, FOREST FIRE) events
-    in Indonesia. DesInventar records: 14 events with data out of 2,827 total wildfire
-    events (2005-2012)., Observed hectares of crops/woods destroyed or affected from
-    coastal flood (SURGE) events in Indonesia. DesInventar records: 5 events with
-    data out of 270 total coastal flood events (2009-2011)., Observed hectares of
-    crops/woods destroyed or affected from drought (DROUGHT) events in Indonesia.
-    DesInventar records: 1,352 events with data out of 1,748 total drought events
-    (2004-2008)., Observed hectares of crops/woods destroyed or affected from earthquake
-    (EARTHQUAKE) events in Indonesia. DesInventar records: 5 events with data out
-    of 449 total earthquake events (1976-2004)., Observed hectares of crops/woods
-    destroyed or affected from tsunami (TSUNAMI) events in Indonesia. DesInventar
-    records: 2 events with data out of 13 total tsunami events (1973-1977)., Observed
-    hectares of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE)
-    events in Indonesia. DesInventar records: 12 events with data out of 2,827 total
-    wildfire events (2005-2012)., Observed homes destroyed beyond habitability from
-    coastal flood (SURGE) events in Indonesia. DesInventar records: 93 events with
-    data out of 270 total coastal flood events (2009-2011)., Observed homes destroyed
-    beyond habitability from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
-    records: 188 events with data out of 449 total earthquake events (1976-2004).,
-    Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events in
-    Indonesia. DesInventar records: 6 events with data out of 13 total tsunami events
-    (1973-1977)., Observed homes destroyed beyond habitability from wildfire (FIRE,
-    FOREST FIRE) events in Indonesia. DesInventar records: 1,088 events with data
-    out of 2,827 total wildfire events (2005-2012)., Observed homes with non-structural
-    damage, still habitable from coastal flood (SURGE) events in Indonesia. DesInventar
-    records: 55 events with data out of 270 total coastal flood events (2009-2011).,
-    Observed homes with non-structural damage, still habitable from earthquake (EARTHQUAKE)
-    events in Indonesia. DesInventar records: 171 events with data out of 449 total
-    earthquake events (1976-2004)., Observed homes with non-structural damage, still
-    habitable from tsunami (TSUNAMI) events in Indonesia. DesInventar records: 1 events
-    with data out of 13 total tsunami events (1973-1977)., Observed homes with non-structural
-    damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Indonesia.
-    DesInventar records: 92 events with data out of 2,827 total wildfire events (2005-2012).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from coastal flood (SURGE) events in Indonesia. DesInventar records: 32 events
-    with data out of 270 total coastal flood events (2009-2011)., Observed persons
-    indirectly affected (disruption to services, commerce, work) from drought (DROUGHT)
-    events in Indonesia. DesInventar records: 38 events with data out of 1,748 total
-    drought events (2004-2008)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from earthquake (EARTHQUAKE) events in Indonesia.
-    DesInventar records: 29 events with data out of 449 total earthquake events (1976-2004).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 512
-    events with data out of 2,827 total wildfire events (2005-2012)., Observed persons
-    injured or made sick directly by disaster events from coastal flood (SURGE) events
-    in Indonesia. DesInventar records: 18 events with data out of 270 total coastal
-    flood events (2009-2011)., Observed persons injured or made sick directly by disaster
-    events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records:
-    169 events with data out of 449 total earthquake events (1976-2004)., Observed
-    persons injured or made sick directly by disaster events from tsunami (TSUNAMI)
-    events in Indonesia. DesInventar records: 3 events with data out of 13 total tsunami
-    events (1973-1977)., Observed persons injured or made sick directly by disaster
-    events from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records:
-    166 events with data out of 2,827 total wildfire events (2005-2012)., Observed
-    persons missing or unaccounted for after disaster events from coastal flood (SURGE)
-    events in Indonesia. DesInventar records: 7 events with data out of 270 total
-    coastal flood events (2009-2011)., Observed persons missing or unaccounted for
-    after disaster events from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
-    records: 10 events with data out of 449 total earthquake events (1976-2004).,
-    Observed persons missing or unaccounted for after disaster events from tsunami
-    (TSUNAMI) events in Indonesia. DesInventar records: 6 events with data out of
-    13 total tsunami events (1973-1977)., Observed persons missing or unaccounted
-    for after disaster events from wildfire (FIRE, FOREST FIRE) events in Indonesia.
-    DesInventar records: 5 events with data out of 2,827 total wildfire events (2005-2012).,
-    Observed persons temporarily evacuated from homes or workplaces from coastal flood
-    (SURGE) events in Indonesia. DesInventar records: 54 events with data out of 270
-    total coastal flood events (2009-2011)., Observed persons temporarily evacuated
-    from homes or workplaces from earthquake (EARTHQUAKE) events in Indonesia. DesInventar
-    records: 103 events with data out of 449 total earthquake events (1976-2004).,
-    Observed persons temporarily evacuated from homes or workplaces from tsunami (TSUNAMI)
-    events in Indonesia. DesInventar records: 2 events with data out of 13 total tsunami
-    events (1973-1977)., Observed persons temporarily evacuated from homes or workplaces
-    from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 465
-    events with data out of 2,827 total wildfire events (2005-2012)., Observed total
-    economic losses in local currency from coastal flood (SURGE) events in Indonesia.
-    DesInventar records: 38 events with data out of 270 total coastal flood events
-    (2009-2011)., Observed total economic losses in local currency from drought (DROUGHT)
-    events in Indonesia. DesInventar records: 8 events with data out of 1,748 total
-    drought events (2004-2008)., Observed total economic losses in local currency
-    from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 32 events
-    with data out of 449 total earthquake events (1976-2004)., Observed total economic
-    losses in local currency from wildfire (FIRE, FOREST FIRE) events in Indonesia.
-    DesInventar records: 1,310 events with data out of 2,827 total wildfire events
-    (2005-2012).'
+  description: 46 loss records across 5 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -157,6 +46,161 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 46
+  loss_groups:
+  - count: 11
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from coastal flood (SURGE) events in Indonesia. DesInventar records: 32 events
+      with data out of 270 total coastal flood events (2009-2011).'
+    - 'Observed hectares of crops/woods destroyed or affected from coastal flood (SURGE)
+      events in Indonesia. DesInventar records: 5 events with data out of 270 total
+      coastal flood events (2009-2011).'
+    - 'Observed deaths directly caused by disaster events from coastal flood (SURGE)
+      events in Indonesia. DesInventar records: 17 events with data out of 270 total
+      coastal flood events (2009-2011).'
+    - 'Observed educational facilities destroyed or affected from coastal flood (SURGE)
+      events in Indonesia. DesInventar records: 11 events with data out of 270 total
+      coastal flood events (2009-2011).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from coastal
+      flood (SURGE) events in Indonesia. DesInventar records: 54 events with data
+      out of 270 total coastal flood events (2009-2011).'
+    - 'Observed health facilities destroyed or affected from coastal flood (SURGE)
+      events in Indonesia. DesInventar records: 6 events with data out of 270 total
+      coastal flood events (2009-2011).'
+    - 'Observed homes with non-structural damage, still habitable from coastal flood
+      (SURGE) events in Indonesia. DesInventar records: 55 events with data out of
+      270 total coastal flood events (2009-2011).'
+    - 'Observed homes destroyed beyond habitability from coastal flood (SURGE) events
+      in Indonesia. DesInventar records: 93 events with data out of 270 total coastal
+      flood events (2009-2011).'
+    - 'Observed persons injured or made sick directly by disaster events from coastal
+      flood (SURGE) events in Indonesia. DesInventar records: 18 events with data
+      out of 270 total coastal flood events (2009-2011).'
+    - 'Observed total economic losses in local currency from coastal flood (SURGE)
+      events in Indonesia. DesInventar records: 38 events with data out of 270 total
+      coastal flood events (2009-2011).'
+    - 'Observed persons missing or unaccounted for after disaster events from coastal
+      flood (SURGE) events in Indonesia. DesInventar records: 7 events with data out
+      of 270 total coastal flood events (2009-2011).'
+    hazard_type: coastal_flood
+  - count: 4
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Indonesia. DesInventar records: 38 events with
+      data out of 1,748 total drought events (2004-2008).'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Indonesia. DesInventar records: 1,352 events with data out of 1,748
+      total drought events (2004-2008).'
+    - 'Observed deaths directly caused by disaster events from drought (DROUGHT) events
+      in Indonesia. DesInventar records: 1 events with data out of 1,748 total drought
+      events (2004-2008).'
+    - 'Observed total economic losses in local currency from drought (DROUGHT) events
+      in Indonesia. DesInventar records: 8 events with data out of 1,748 total drought
+      events (2004-2008).'
+    hazard_type: drought
+  - count: 11
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from earthquake (EARTHQUAKE) events in Indonesia. DesInventar records: 29 events
+      with data out of 449 total earthquake events (1976-2004).'
+    - 'Observed hectares of crops/woods destroyed or affected from earthquake (EARTHQUAKE)
+      events in Indonesia. DesInventar records: 5 events with data out of 449 total
+      earthquake events (1976-2004).'
+    - 'Observed deaths directly caused by disaster events from earthquake (EARTHQUAKE)
+      events in Indonesia. DesInventar records: 165 events with data out of 449 total
+      earthquake events (1976-2004).'
+    - 'Observed educational facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Indonesia. DesInventar records: 171 events with data out of 449 total
+      earthquake events (1976-2004).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from earthquake
+      (EARTHQUAKE) events in Indonesia. DesInventar records: 103 events with data
+      out of 449 total earthquake events (1976-2004).'
+    - 'Observed health facilities destroyed or affected from earthquake (EARTHQUAKE)
+      events in Indonesia. DesInventar records: 83 events with data out of 449 total
+      earthquake events (1976-2004).'
+    - 'Observed homes with non-structural damage, still habitable from earthquake
+      (EARTHQUAKE) events in Indonesia. DesInventar records: 171 events with data
+      out of 449 total earthquake events (1976-2004).'
+    - 'Observed homes destroyed beyond habitability from earthquake (EARTHQUAKE) events
+      in Indonesia. DesInventar records: 188 events with data out of 449 total earthquake
+      events (1976-2004).'
+    - 'Observed persons injured or made sick directly by disaster events from earthquake
+      (EARTHQUAKE) events in Indonesia. DesInventar records: 169 events with data
+      out of 449 total earthquake events (1976-2004).'
+    - 'Observed total economic losses in local currency from earthquake (EARTHQUAKE)
+      events in Indonesia. DesInventar records: 32 events with data out of 449 total
+      earthquake events (1976-2004).'
+    - 'Observed persons missing or unaccounted for after disaster events from earthquake
+      (EARTHQUAKE) events in Indonesia. DesInventar records: 10 events with data out
+      of 449 total earthquake events (1976-2004).'
+    hazard_type: earthquake
+  - count: 9
+    descriptions:
+    - 'Observed hectares of crops/woods destroyed or affected from tsunami (TSUNAMI)
+      events in Indonesia. DesInventar records: 2 events with data out of 13 total
+      tsunami events (1973-1977).'
+    - 'Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events
+      in Indonesia. DesInventar records: 11 events with data out of 13 total tsunami
+      events (1973-1977).'
+    - 'Observed educational facilities destroyed or affected from tsunami (TSUNAMI)
+      events in Indonesia. DesInventar records: 2 events with data out of 13 total
+      tsunami events (1973-1977).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from tsunami
+      (TSUNAMI) events in Indonesia. DesInventar records: 2 events with data out of
+      13 total tsunami events (1973-1977).'
+    - 'Observed health facilities destroyed or affected from tsunami (TSUNAMI) events
+      in Indonesia. DesInventar records: 1 events with data out of 13 total tsunami
+      events (1973-1977).'
+    - 'Observed homes with non-structural damage, still habitable from tsunami (TSUNAMI)
+      events in Indonesia. DesInventar records: 1 events with data out of 13 total
+      tsunami events (1973-1977).'
+    - 'Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events
+      in Indonesia. DesInventar records: 6 events with data out of 13 total tsunami
+      events (1973-1977).'
+    - 'Observed persons injured or made sick directly by disaster events from tsunami
+      (TSUNAMI) events in Indonesia. DesInventar records: 3 events with data out of
+      13 total tsunami events (1973-1977).'
+    - 'Observed persons missing or unaccounted for after disaster events from tsunami
+      (TSUNAMI) events in Indonesia. DesInventar records: 6 events with data out of
+      13 total tsunami events (1973-1977).'
+    hazard_type: tsunami
+  - count: 11
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Indonesia. DesInventar records:
+      512 events with data out of 2,827 total wildfire events (2005-2012).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Indonesia. DesInventar records: 12 events with data out
+      of 2,827 total wildfire events (2005-2012).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Indonesia. DesInventar records: 145 events with data out of
+      2,827 total wildfire events (2005-2012).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Indonesia. DesInventar records: 50 events with data out
+      of 2,827 total wildfire events (2005-2012).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from wildfire
+      (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 465 events with
+      data out of 2,827 total wildfire events (2005-2012).'
+    - 'Observed health facilities destroyed or affected from wildfire (FIRE, FOREST
+      FIRE) events in Indonesia. DesInventar records: 14 events with data out of 2,827
+      total wildfire events (2005-2012).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Indonesia. DesInventar records: 92 events with data out
+      of 2,827 total wildfire events (2005-2012).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Indonesia. DesInventar records: 1,088 events with data out of 2,827
+      total wildfire events (2005-2012).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 166 events with
+      data out of 2,827 total wildfire events (2005-2012).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Indonesia. DesInventar records: 1,310 events with data out of
+      2,827 total wildfire events (2005-2012).'
+    - 'Observed persons missing or unaccounted for after disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Indonesia. DesInventar records: 5 events with
+      data out of 2,827 total wildfire events (2005-2012).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-kenundrr_desinventar.md
+++ b/_datasets/rdls_lss-kenundrr_desinventar.md
@@ -36,132 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from convective
-    storm (THUNDERSTORM) events in Kenya. DesInventar records: 14 events with data
-    out of 19 total convective storm events (2011-2013)., Observed deaths directly
-    caused by disaster events from flood (FLOOD) events in Kenya. DesInventar records:
-    236 events with data out of 737 total flood events (2011-2014)., Observed deaths
-    directly caused by disaster events from flood (RAINS) events in Kenya. DesInventar
-    records: 6 events with data out of 48 total flood events (2015-2016)., Observed
-    deaths directly caused by disaster events from landslide (LANDSLIDE) events in
-    Kenya. DesInventar records: 26 events with data out of 44 total landslide events
-    (2013-2016)., Observed deaths directly caused by disaster events from landslide
-    (MUDSLIDE) events in Kenya. DesInventar records: 4 events with data out of 6 total
-    landslide events (2009-2015)., Observed deaths directly caused by disaster events
-    from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 6 events
-    with data out of 19 total strong wind events (2010-2015)., Observed deaths directly
-    caused by disaster events from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar
-    records: 114 events with data out of 415 total wildfire events (1997-2016)., Observed
-    educational facilities destroyed or affected from convective storm (THUNDERSTORM)
-    events in Kenya. DesInventar records: 1 events with data out of 19 total convective
-    storm events (2011-2013)., Observed educational facilities destroyed or affected
-    from flood (FLOOD) events in Kenya. DesInventar records: 1 events with data out
-    of 737 total flood events (2011-2014)., Observed educational facilities destroyed
-    or affected from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records:
-    1 events with data out of 19 total strong wind events (2010-2015)., Observed hectares
-    of crops/woods destroyed or affected from flood (FLOOD) events in Kenya. DesInventar
-    records: 34 events with data out of 737 total flood events (2011-2014)., Observed
-    hectares of crops/woods destroyed or affected from landslide (LANDSLIDE) events
-    in Kenya. DesInventar records: 1 events with data out of 44 total landslide events
-    (2013-2016)., Observed hectares of crops/woods destroyed or affected from wildfire
-    (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 23 events with data
-    out of 415 total wildfire events (1997-2016)., Observed homes destroyed beyond
-    habitability from convective storm (THUNDERSTORM) events in Kenya. DesInventar
-    records: 1 events with data out of 19 total convective storm events (2011-2013).,
-    Observed homes destroyed beyond habitability from flood (FLOOD) events in Kenya.
-    DesInventar records: 136 events with data out of 737 total flood events (2011-2014).,
-    Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
-    in Kenya. DesInventar records: 13 events with data out of 44 total landslide events
-    (2013-2016)., Observed homes destroyed beyond habitability from wildfire (FIRE,
-    FOREST FIRE) events in Kenya. DesInventar records: 69 events with data out of
-    415 total wildfire events (1997-2016)., Observed homes with non-structural damage,
-    still habitable from convective storm (THUNDERSTORM) events in Kenya. DesInventar
-    records: 1 events with data out of 19 total convective storm events (2011-2013).,
-    Observed homes with non-structural damage, still habitable from flood (FLOOD)
-    events in Kenya. DesInventar records: 32 events with data out of 737 total flood
-    events (2011-2014)., Observed homes with non-structural damage, still habitable
-    from flood (RAINS) events in Kenya. DesInventar records: 1 events with data out
-    of 48 total flood events (2015-2016)., Observed homes with non-structural damage,
-    still habitable from landslide (LANDSLIDE) events in Kenya. DesInventar records:
-    2 events with data out of 44 total landslide events (2013-2016)., Observed homes
-    with non-structural damage, still habitable from strong wind (STORM, WINDSTORM)
-    events in Kenya. DesInventar records: 4 events with data out of 19 total strong
-    wind events (2010-2015)., Observed homes with non-structural damage, still habitable
-    from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 15 events
-    with data out of 415 total wildfire events (1997-2016)., Observed livestock lost
-    from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 2 events
-    with data out of 19 total convective storm events (2011-2013)., Observed livestock
-    lost from drought (DROUGHT) events in Kenya. DesInventar records: 1 events with
-    data out of 569 total drought events (2009-2011)., Observed livestock lost from
-    flood (FLOOD) events in Kenya. DesInventar records: 20 events with data out of
-    737 total flood events (2011-2014)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from convective storm (THUNDERSTORM) events in Kenya.
-    DesInventar records: 1 events with data out of 19 total convective storm events
-    (2011-2013)., Observed persons indirectly affected (disruption to services, commerce,
-    work) from drought (DROUGHT) events in Kenya. DesInventar records: 165 events
-    with data out of 569 total drought events (2009-2011)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from flood (FLOOD) events in
-    Kenya. DesInventar records: 207 events with data out of 737 total flood events
-    (2011-2014)., Observed persons indirectly affected (disruption to services, commerce,
-    work) from landslide (LANDSLIDE) events in Kenya. DesInventar records: 11 events
-    with data out of 44 total landslide events (2013-2016)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from strong wind (STORM, WINDSTORM)
-    events in Kenya. DesInventar records: 5 events with data out of 19 total strong
-    wind events (2010-2015)., Observed persons indirectly affected (disruption to
-    services, commerce, work) from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar
-    records: 3 events with data out of 415 total wildfire events (1997-2016)., Observed
-    persons injured or made sick directly by disaster events from convective storm
-    (THUNDERSTORM) events in Kenya. DesInventar records: 7 events with data out of
-    19 total convective storm events (2011-2013)., Observed persons injured or made
-    sick directly by disaster events from flood (FLOOD) events in Kenya. DesInventar
-    records: 23 events with data out of 737 total flood events (2011-2014)., Observed
-    persons injured or made sick directly by disaster events from flood (RAINS) events
-    in Kenya. DesInventar records: 1 events with data out of 48 total flood events
-    (2015-2016)., Observed persons injured or made sick directly by disaster events
-    from landslide (LANDSLIDE) events in Kenya. DesInventar records: 5 events with
-    data out of 44 total landslide events (2013-2016)., Observed persons injured or
-    made sick directly by disaster events from landslide (MUDSLIDE) events in Kenya.
-    DesInventar records: 1 events with data out of 6 total landslide events (2009-2015).,
-    Observed persons injured or made sick directly by disaster events from strong
-    wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with data
-    out of 19 total strong wind events (2010-2015)., Observed persons injured or made
-    sick directly by disaster events from wildfire (FIRE, FOREST FIRE) events in Kenya.
-    DesInventar records: 79 events with data out of 415 total wildfire events (1997-2016).,
-    Observed persons missing or unaccounted for after disaster events from convective
-    storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data
-    out of 19 total convective storm events (2011-2013)., Observed persons missing
-    or unaccounted for after disaster events from flood (FLOOD) events in Kenya. DesInventar
-    records: 9 events with data out of 737 total flood events (2011-2014)., Observed
-    persons missing or unaccounted for after disaster events from landslide (LANDSLIDE)
-    events in Kenya. DesInventar records: 1 events with data out of 44 total landslide
-    events (2013-2016)., Observed persons missing or unaccounted for after disaster
-    events from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records:
-    1 events with data out of 19 total strong wind events (2010-2015)., Observed persons
-    permanently relocated from homes from flood (FLOOD) events in Kenya. DesInventar
-    records: 14 events with data out of 737 total flood events (2011-2014)., Observed
-    persons permanently relocated from homes from landslide (LANDSLIDE) events in
-    Kenya. DesInventar records: 2 events with data out of 44 total landslide events
-    (2013-2016)., Observed persons permanently relocated from homes from wildfire
-    (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 1 events with data out
-    of 415 total wildfire events (1997-2016)., Observed persons temporarily evacuated
-    from homes or workplaces from flood (FLOOD) events in Kenya. DesInventar records:
-    9 events with data out of 737 total flood events (2011-2014)., Observed persons
-    whose goods/services suffered serious damage from drought (DROUGHT) events in
-    Kenya. DesInventar records: 2 events with data out of 569 total drought events
-    (2009-2011)., Observed persons whose goods/services suffered serious damage from
-    flood (FLOOD) events in Kenya. DesInventar records: 2 events with data out of
-    737 total flood events (2011-2014)., Observed persons whose goods/services suffered
-    serious damage from flood (RAINS) events in Kenya. DesInventar records: 38 events
-    with data out of 48 total flood events (2015-2016)., Observed total economic losses
-    in local currency from convective storm (THUNDERSTORM) events in Kenya. DesInventar
-    records: 1 events with data out of 19 total convective storm events (2011-2013).,
-    Observed total economic losses in local currency from flood (FLOOD) events in
-    Kenya. DesInventar records: 2 events with data out of 737 total flood events (2011-2014).,
-    Observed total economic losses in local currency from strong wind (STORM, WINDSTORM)
-    events in Kenya. DesInventar records: 1 events with data out of 19 total strong
-    wind events (2010-2015)., Observed total economic losses in local currency from
-    wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 16 events with
-    data out of 415 total wildfire events (1997-2016).'
+  description: 54 loss records across 6 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -172,6 +47,185 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 54
+  loss_groups:
+  - count: 9
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from convective storm (THUNDERSTORM) events in Kenya. DesInventar records: 1
+      events with data out of 19 total convective storm events (2011-2013).'
+    - 'Observed deaths directly caused by disaster events from convective storm (THUNDERSTORM)
+      events in Kenya. DesInventar records: 14 events with data out of 19 total convective
+      storm events (2011-2013).'
+    - 'Observed educational facilities destroyed or affected from convective storm
+      (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data out
+      of 19 total convective storm events (2011-2013).'
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data
+      out of 19 total convective storm events (2011-2013).'
+    - 'Observed homes destroyed beyond habitability from convective storm (THUNDERSTORM)
+      events in Kenya. DesInventar records: 1 events with data out of 19 total convective
+      storm events (2011-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from convective
+      storm (THUNDERSTORM) events in Kenya. DesInventar records: 7 events with data
+      out of 19 total convective storm events (2011-2013).'
+    - 'Observed total economic losses in local currency from convective storm (THUNDERSTORM)
+      events in Kenya. DesInventar records: 1 events with data out of 19 total convective
+      storm events (2011-2013).'
+    - 'Observed livestock lost from convective storm (THUNDERSTORM) events in Kenya.
+      DesInventar records: 2 events with data out of 19 total convective storm events
+      (2011-2013).'
+    - 'Observed persons missing or unaccounted for after disaster events from convective
+      storm (THUNDERSTORM) events in Kenya. DesInventar records: 1 events with data
+      out of 19 total convective storm events (2011-2013).'
+    hazard_type: convective_storm
+  - count: 3
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Kenya. DesInventar records: 165 events with
+      data out of 569 total drought events (2009-2011).'
+    - 'Observed livestock lost from drought (DROUGHT) events in Kenya. DesInventar
+      records: 1 events with data out of 569 total drought events (2009-2011).'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (DROUGHT) events in Kenya. DesInventar records: 2 events with data out of 569
+      total drought events (2009-2011).'
+    hazard_type: drought
+  - count: 17
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Kenya. DesInventar records: 207 events with data
+      out of 737 total flood events (2011-2014).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Kenya. DesInventar records: 34 events with data out of 737 total flood events
+      (2011-2014).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Kenya. DesInventar records: 236 events with data out of 737 total flood events
+      (2011-2014).'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Kenya. DesInventar records: 1 events with data out of 737 total flood events
+      (2011-2014).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLOOD) events in Kenya. DesInventar records: 9 events with data out of 737
+      total flood events (2011-2014).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Kenya. DesInventar records: 32 events with data out of 737 total flood
+      events (2011-2014).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Kenya.
+      DesInventar records: 136 events with data out of 737 total flood events (2011-2014).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Kenya. DesInventar records: 23 events with data out of 737
+      total flood events (2011-2014).'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Kenya. DesInventar records: 2 events with data out of 737 total flood events
+      (2011-2014).'
+    - 'Observed livestock lost from flood (FLOOD) events in Kenya. DesInventar records:
+      20 events with data out of 737 total flood events (2011-2014).'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLOOD) events in Kenya. DesInventar records: 9 events with data out of 737
+      total flood events (2011-2014).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Kenya. DesInventar records: 14 events with data out of 737 total flood events
+      (2011-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Kenya. DesInventar records: 2 events with data out of 737 total flood
+      events (2011-2014).'
+    - 'Observed deaths directly caused by disaster events from flood (RAINS) events
+      in Kenya. DesInventar records: 6 events with data out of 48 total flood events
+      (2015-2016).'
+    - 'Observed homes with non-structural damage, still habitable from flood (RAINS)
+      events in Kenya. DesInventar records: 1 events with data out of 48 total flood
+      events (2015-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (RAINS) events in Kenya. DesInventar records: 1 events with data out of 48 total
+      flood events (2015-2016).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (RAINS)
+      events in Kenya. DesInventar records: 38 events with data out of 48 total flood
+      events (2015-2016).'
+    hazard_type: flood
+  - count: 10
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (LANDSLIDE) events in Kenya. DesInventar records: 11 events with
+      data out of 44 total landslide events (2013-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from landslide (LANDSLIDE)
+      events in Kenya. DesInventar records: 1 events with data out of 44 total landslide
+      events (2013-2016).'
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Kenya. DesInventar records: 26 events with data out of 44 total landslide
+      events (2013-2016).'
+    - 'Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+      events in Kenya. DesInventar records: 2 events with data out of 44 total landslide
+      events (2013-2016).'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Kenya. DesInventar records: 13 events with data out of 44 total landslide
+      events (2013-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (LANDSLIDE) events in Kenya. DesInventar records: 5 events with data out of
+      44 total landslide events (2013-2016).'
+    - 'Observed persons missing or unaccounted for after disaster events from landslide
+      (LANDSLIDE) events in Kenya. DesInventar records: 1 events with data out of
+      44 total landslide events (2013-2016).'
+    - 'Observed persons permanently relocated from homes from landslide (LANDSLIDE)
+      events in Kenya. DesInventar records: 2 events with data out of 44 total landslide
+      events (2013-2016).'
+    - 'Observed deaths directly caused by disaster events from landslide (MUDSLIDE)
+      events in Kenya. DesInventar records: 4 events with data out of 6 total landslide
+      events (2009-2015).'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (MUDSLIDE) events in Kenya. DesInventar records: 1 events with data out of 6
+      total landslide events (2009-2015).'
+    hazard_type: landslide
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 5
+      events with data out of 19 total strong wind events (2010-2015).'
+    - 'Observed deaths directly caused by disaster events from strong wind (STORM,
+      WINDSTORM) events in Kenya. DesInventar records: 6 events with data out of 19
+      total strong wind events (2010-2015).'
+    - 'Observed educational facilities destroyed or affected from strong wind (STORM,
+      WINDSTORM) events in Kenya. DesInventar records: 1 events with data out of 19
+      total strong wind events (2010-2015).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (STORM, WINDSTORM) events in Kenya. DesInventar records: 4 events with data
+      out of 19 total strong wind events (2010-2015).'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with
+      data out of 19 total strong wind events (2010-2015).'
+    - 'Observed total economic losses in local currency from strong wind (STORM, WINDSTORM)
+      events in Kenya. DesInventar records: 1 events with data out of 19 total strong
+      wind events (2010-2015).'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (STORM, WINDSTORM) events in Kenya. DesInventar records: 1 events with
+      data out of 19 total strong wind events (2010-2015).'
+    hazard_type: strong_wind
+  - count: 8
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 3 events
+      with data out of 415 total wildfire events (1997-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Kenya. DesInventar records: 23 events with data out of
+      415 total wildfire events (1997-2016).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Kenya. DesInventar records: 114 events with data out of 415
+      total wildfire events (1997-2016).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Kenya. DesInventar records: 15 events with data out of
+      415 total wildfire events (1997-2016).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Kenya. DesInventar records: 69 events with data out of 415 total wildfire
+      events (1997-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Kenya. DesInventar records: 79 events with data
+      out of 415 total wildfire events (1997-2016).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Kenya. DesInventar records: 16 events with data out of 415 total
+      wildfire events (1997-2016).'
+    - 'Observed persons permanently relocated from homes from wildfire (FIRE, FOREST
+      FIRE) events in Kenya. DesInventar records: 1 events with data out of 415 total
+      wildfire events (1997-2016).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-khmundrr_desinventar.md
+++ b/_datasets/rdls_lss-khmundrr_desinventar.md
@@ -35,100 +35,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from flood (Flood)
-    events in Cambodia. DesInventar records: 394 events with data out of 3,389 total
-    flood events (2011-2014)., Observed deaths directly caused by disaster events
-    from strong wind (Storm) events in Cambodia. DesInventar records: 58 events with
-    data out of 1,454 total strong wind events (2009-2016)., Observed deaths directly
-    caused by disaster events from wildfire (Fire) events in Cambodia. DesInventar
-    records: 53 events with data out of 1,814 total wildfire events (2013-2016).,
-    Observed educational facilities destroyed or affected from drought (Drought) events
-    in Cambodia. DesInventar records: 1 events with data out of 1,300 total drought
-    events (2011-2016)., Observed educational facilities destroyed or affected from
-    flood (Flood) events in Cambodia. DesInventar records: 59 events with data out
-    of 3,389 total flood events (2011-2014)., Observed educational facilities destroyed
-    or affected from strong wind (Storm) events in Cambodia. DesInventar records:
-    26 events with data out of 1,454 total strong wind events (2009-2016)., Observed
-    health facilities destroyed or affected from flood (Flood) events in Cambodia.
-    DesInventar records: 27 events with data out of 3,389 total flood events (2011-2014).,
-    Observed health facilities destroyed or affected from strong wind (Storm) events
-    in Cambodia. DesInventar records: 7 events with data out of 1,454 total strong
-    wind events (2009-2016)., Observed hectares of crops/woods destroyed or affected
-    from drought (Drought) events in Cambodia. DesInventar records: 552 events with
-    data out of 1,300 total drought events (2011-2016)., Observed hectares of crops/woods
-    destroyed or affected from flood (Flood) events in Cambodia. DesInventar records:
-    1,780 events with data out of 3,389 total flood events (2011-2014)., Observed
-    hectares of crops/woods destroyed or affected from strong wind (Storm) events
-    in Cambodia. DesInventar records: 13 events with data out of 1,454 total strong
-    wind events (2009-2016)., Observed hectares of crops/woods destroyed or affected
-    from wildfire (Fire) events in Cambodia. DesInventar records: 1 events with data
-    out of 1,814 total wildfire events (2013-2016)., Observed homes destroyed beyond
-    habitability from flood (Flood) events in Cambodia. DesInventar records: 184 events
-    with data out of 3,389 total flood events (2011-2014)., Observed homes destroyed
-    beyond habitability from strong wind (Storm) events in Cambodia. DesInventar records:
-    957 events with data out of 1,454 total strong wind events (2009-2016)., Observed
-    homes destroyed beyond habitability from wildfire (Fire) events in Cambodia. DesInventar
-    records: 1,249 events with data out of 1,814 total wildfire events (2013-2016).,
-    Observed homes with non-structural damage, still habitable from flood (Flood)
-    events in Cambodia. DesInventar records: 222 events with data out of 3,389 total
-    flood events (2011-2014)., Observed homes with non-structural damage, still habitable
-    from strong wind (Storm) events in Cambodia. DesInventar records: 787 events with
-    data out of 1,454 total strong wind events (2009-2016)., Observed homes with non-structural
-    damage, still habitable from wildfire (Fire) events in Cambodia. DesInventar records:
-    220 events with data out of 1,814 total wildfire events (2013-2016)., Observed
-    livestock lost from drought (Drought) events in Cambodia. DesInventar records:
-    2 events with data out of 1,300 total drought events (2011-2016)., Observed livestock
-    lost from flood (Flood) events in Cambodia. DesInventar records: 88 events with
-    data out of 3,389 total flood events (2011-2014)., Observed livestock lost from
-    strong wind (Storm) events in Cambodia. DesInventar records: 23 events with data
-    out of 1,454 total strong wind events (2009-2016)., Observed livestock lost from
-    wildfire (Fire) events in Cambodia. DesInventar records: 2 events with data out
-    of 1,814 total wildfire events (2013-2016)., Observed metres of transport networks
-    destroyed from drought (Drought) events in Cambodia. DesInventar records: 4 events
-    with data out of 1,300 total drought events (2011-2016)., Observed metres of transport
-    networks destroyed from flood (Flood) events in Cambodia. DesInventar records:
-    983 events with data out of 3,389 total flood events (2011-2014)., Observed metres
-    of transport networks destroyed from strong wind (Storm) events in Cambodia. DesInventar
-    records: 3 events with data out of 1,454 total strong wind events (2009-2016).,
-    Observed persons indirectly affected (disruption to services, commerce, work)
-    from drought (Drought) events in Cambodia. DesInventar records: 32 events with
-    data out of 1,300 total drought events (2011-2016)., Observed persons indirectly
-    affected (disruption to services, commerce, work) from strong wind (Storm) events
-    in Cambodia. DesInventar records: 4 events with data out of 1,454 total strong
-    wind events (2009-2016)., Observed persons indirectly affected (disruption to
-    services, commerce, work) from wildfire (Fire) events in Cambodia. DesInventar
-    records: 5 events with data out of 1,814 total wildfire events (2013-2016)., Observed
-    persons injured or made sick directly by disaster events from flood (Flood) events
-    in Cambodia. DesInventar records: 38 events with data out of 3,389 total flood
-    events (2011-2014)., Observed persons injured or made sick directly by disaster
-    events from strong wind (Storm) events in Cambodia. DesInventar records: 128 events
-    with data out of 1,454 total strong wind events (2009-2016)., Observed persons
-    injured or made sick directly by disaster events from wildfire (Fire) events in
-    Cambodia. DesInventar records: 46 events with data out of 1,814 total wildfire
-    events (2013-2016)., Observed persons missing or unaccounted for after disaster
-    events from strong wind (Storm) events in Cambodia. DesInventar records: 1 events
-    with data out of 1,454 total strong wind events (2009-2016)., Observed persons
-    permanently relocated from homes from flood (Flood) events in Cambodia. DesInventar
-    records: 15 events with data out of 3,389 total flood events (2011-2014)., Observed
-    persons temporarily evacuated from homes or workplaces from flood (Flood) events
-    in Cambodia. DesInventar records: 421 events with data out of 3,389 total flood
-    events (2011-2014)., Observed persons temporarily evacuated from homes or workplaces
-    from strong wind (Storm) events in Cambodia. DesInventar records: 2 events with
-    data out of 1,454 total strong wind events (2009-2016)., Observed persons temporarily
-    evacuated from homes or workplaces from wildfire (Fire) events in Cambodia. DesInventar
-    records: 2 events with data out of 1,814 total wildfire events (2013-2016)., Observed
-    persons whose goods/services suffered serious damage from drought (Drought) events
-    in Cambodia. DesInventar records: 334 events with data out of 1,300 total drought
-    events (2011-2016)., Observed persons whose goods/services suffered serious damage
-    from flood (Flood) events in Cambodia. DesInventar records: 1,546 events with
-    data out of 3,389 total flood events (2011-2014)., Observed persons whose goods/services
-    suffered serious damage from strong wind (Storm) events in Cambodia. DesInventar
-    records: 681 events with data out of 1,454 total strong wind events (2009-2016).,
-    Observed persons whose goods/services suffered serious damage from wildfire (Fire)
-    events in Cambodia. DesInventar records: 579 events with data out of 1,814 total
-    wildfire events (2013-2016)., Observed total economic losses in US Dollars from
-    wildfire (Fire) events in Cambodia. DesInventar records: 1 events with data out
-    of 1,814 total wildfire events (2013-2016).'
+  description: 41 loss records across 4 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -138,6 +45,138 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 41
+  loss_groups:
+  - count: 6
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (Drought) events in Cambodia. DesInventar records: 32 events with
+      data out of 1,300 total drought events (2011-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (Drought)
+      events in Cambodia. DesInventar records: 552 events with data out of 1,300 total
+      drought events (2011-2016).'
+    - 'Observed metres of transport networks destroyed from drought (Drought) events
+      in Cambodia. DesInventar records: 4 events with data out of 1,300 total drought
+      events (2011-2016).'
+    - 'Observed educational facilities destroyed or affected from drought (Drought)
+      events in Cambodia. DesInventar records: 1 events with data out of 1,300 total
+      drought events (2011-2016).'
+    - 'Observed livestock lost from drought (Drought) events in Cambodia. DesInventar
+      records: 2 events with data out of 1,300 total drought events (2011-2016).'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (Drought) events in Cambodia. DesInventar records: 334 events with data out
+      of 1,300 total drought events (2011-2016).'
+    hazard_type: drought
+  - count: 12
+    descriptions:
+    - 'Observed hectares of crops/woods destroyed or affected from flood (Flood) events
+      in Cambodia. DesInventar records: 1,780 events with data out of 3,389 total
+      flood events (2011-2014).'
+    - 'Observed metres of transport networks destroyed from flood (Flood) events in
+      Cambodia. DesInventar records: 983 events with data out of 3,389 total flood
+      events (2011-2014).'
+    - 'Observed deaths directly caused by disaster events from flood (Flood) events
+      in Cambodia. DesInventar records: 394 events with data out of 3,389 total flood
+      events (2011-2014).'
+    - 'Observed educational facilities destroyed or affected from flood (Flood) events
+      in Cambodia. DesInventar records: 59 events with data out of 3,389 total flood
+      events (2011-2014).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (Flood) events in Cambodia. DesInventar records: 421 events with data out of
+      3,389 total flood events (2011-2014).'
+    - 'Observed health facilities destroyed or affected from flood (Flood) events
+      in Cambodia. DesInventar records: 27 events with data out of 3,389 total flood
+      events (2011-2014).'
+    - 'Observed homes with non-structural damage, still habitable from flood (Flood)
+      events in Cambodia. DesInventar records: 222 events with data out of 3,389 total
+      flood events (2011-2014).'
+    - 'Observed homes destroyed beyond habitability from flood (Flood) events in Cambodia.
+      DesInventar records: 184 events with data out of 3,389 total flood events (2011-2014).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (Flood) events in Cambodia. DesInventar records: 38 events with data out of
+      3,389 total flood events (2011-2014).'
+    - 'Observed livestock lost from flood (Flood) events in Cambodia. DesInventar
+      records: 88 events with data out of 3,389 total flood events (2011-2014).'
+    - 'Observed persons permanently relocated from homes from flood (Flood) events
+      in Cambodia. DesInventar records: 15 events with data out of 3,389 total flood
+      events (2011-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (Flood)
+      events in Cambodia. DesInventar records: 1,546 events with data out of 3,389
+      total flood events (2011-2014).'
+    hazard_type: flood
+  - count: 13
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (Storm) events in Cambodia. DesInventar records: 4 events with
+      data out of 1,454 total strong wind events (2009-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from strong wind (Storm)
+      events in Cambodia. DesInventar records: 13 events with data out of 1,454 total
+      strong wind events (2009-2016).'
+    - 'Observed metres of transport networks destroyed from strong wind (Storm) events
+      in Cambodia. DesInventar records: 3 events with data out of 1,454 total strong
+      wind events (2009-2016).'
+    - 'Observed deaths directly caused by disaster events from strong wind (Storm)
+      events in Cambodia. DesInventar records: 58 events with data out of 1,454 total
+      strong wind events (2009-2016).'
+    - 'Observed educational facilities destroyed or affected from strong wind (Storm)
+      events in Cambodia. DesInventar records: 26 events with data out of 1,454 total
+      strong wind events (2009-2016).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (Storm) events in Cambodia. DesInventar records: 2 events with data out
+      of 1,454 total strong wind events (2009-2016).'
+    - 'Observed health facilities destroyed or affected from strong wind (Storm) events
+      in Cambodia. DesInventar records: 7 events with data out of 1,454 total strong
+      wind events (2009-2016).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (Storm) events in Cambodia. DesInventar records: 787 events with data out of
+      1,454 total strong wind events (2009-2016).'
+    - 'Observed homes destroyed beyond habitability from strong wind (Storm) events
+      in Cambodia. DesInventar records: 957 events with data out of 1,454 total strong
+      wind events (2009-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (Storm) events in Cambodia. DesInventar records: 128 events with data out
+      of 1,454 total strong wind events (2009-2016).'
+    - 'Observed livestock lost from strong wind (Storm) events in Cambodia. DesInventar
+      records: 23 events with data out of 1,454 total strong wind events (2009-2016).'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (Storm) events in Cambodia. DesInventar records: 1 events with data out
+      of 1,454 total strong wind events (2009-2016).'
+    - 'Observed persons whose goods/services suffered serious damage from strong wind
+      (Storm) events in Cambodia. DesInventar records: 681 events with data out of
+      1,454 total strong wind events (2009-2016).'
+    hazard_type: strong_wind
+  - count: 10
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (Fire) events in Cambodia. DesInventar records: 5 events with
+      data out of 1,814 total wildfire events (2013-2016).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (Fire)
+      events in Cambodia. DesInventar records: 1 events with data out of 1,814 total
+      wildfire events (2013-2016).'
+    - 'Observed deaths directly caused by disaster events from wildfire (Fire) events
+      in Cambodia. DesInventar records: 53 events with data out of 1,814 total wildfire
+      events (2013-2016).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from wildfire
+      (Fire) events in Cambodia. DesInventar records: 2 events with data out of 1,814
+      total wildfire events (2013-2016).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (Fire)
+      events in Cambodia. DesInventar records: 220 events with data out of 1,814 total
+      wildfire events (2013-2016).'
+    - 'Observed homes destroyed beyond habitability from wildfire (Fire) events in
+      Cambodia. DesInventar records: 1,249 events with data out of 1,814 total wildfire
+      events (2013-2016).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (Fire) events in Cambodia. DesInventar records: 46 events with data out of 1,814
+      total wildfire events (2013-2016).'
+    - 'Observed total economic losses in US Dollars from wildfire (Fire) events in
+      Cambodia. DesInventar records: 1 events with data out of 1,814 total wildfire
+      events (2013-2016).'
+    - 'Observed livestock lost from wildfire (Fire) events in Cambodia. DesInventar
+      records: 2 events with data out of 1,814 total wildfire events (2013-2016).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (Fire) events in Cambodia. DesInventar records: 579 events with data out of
+      1,814 total wildfire events (2013-2016).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-lkaundrr_desinventar.md
+++ b/_datasets/rdls_lss-lkaundrr_desinventar.md
@@ -36,168 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from coastal flood
-    (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 4 events with data
-    out of 40 total coastal flood events., Observed deaths directly caused by disaster
-    events from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records:
-    1 events with data out of 20 total convective storm events., Observed deaths directly
-    caused by disaster events from drought (DROUGHT) events in Sri Lanka. DesInventar
-    records: 1 events with data out of 2,242 total drought events., Observed deaths
-    directly caused by disaster events from flood (FLASH FLOOD, FLOOD) events in Sri
-    Lanka. DesInventar records: 252 events with data out of 6,828 total flood events.,
-    Observed deaths directly caused by disaster events from flood (RAINS) events in
-    Sri Lanka. DesInventar records: 23 events with data out of 2,533 total flood events.,
-    Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
-    events in Sri Lanka. DesInventar records: 174 events with data out of 2,100 total
-    landslide events., Observed deaths directly caused by disaster events from strong
-    wind (CYCLONE) events in Sri Lanka. DesInventar records: 27 events with data out
-    of 164 total strong wind events., Observed deaths directly caused by disaster
-    events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 13 events
-    with data out of 89 total tsunami events., Observed deaths directly caused by
-    disaster events from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar
-    records: 61 events with data out of 3,697 total wildfire events., Observed educational
-    facilities destroyed or affected from flood (FLASH FLOOD, FLOOD) events in Sri
-    Lanka. DesInventar records: 2 events with data out of 6,828 total flood events.,
-    Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD)
-    events in Sri Lanka. DesInventar records: 1 events with data out of 6,828 total
-    flood events., Observed hectares of crops/woods destroyed or affected from drought
-    (DROUGHT) events in Sri Lanka. DesInventar records: 97 events with data out of
-    2,242 total drought events., Observed hectares of crops/woods destroyed or affected
-    from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 5 events
-    with data out of 6,828 total flood events., Observed homes destroyed beyond habitability
-    from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records:
-    2 events with data out of 40 total coastal flood events., Observed homes destroyed
-    beyond habitability from convective storm (HAILSTORM) events in Sri Lanka. DesInventar
-    records: 1 events with data out of 20 total convective storm events., Observed
-    homes destroyed beyond habitability from drought (DROUGHT) events in Sri Lanka.
-    DesInventar records: 1 events with data out of 2,242 total drought events., Observed
-    homes destroyed beyond habitability from flood (FLASH FLOOD, FLOOD) events in
-    Sri Lanka. DesInventar records: 1,229 events with data out of 6,828 total flood
-    events., Observed homes destroyed beyond habitability from flood (RAINS) events
-    in Sri Lanka. DesInventar records: 198 events with data out of 2,533 total flood
-    events., Observed homes destroyed beyond habitability from landslide (LANDSLIDE)
-    events in Sri Lanka. DesInventar records: 316 events with data out of 2,100 total
-    landslide events., Observed homes destroyed beyond habitability from strong wind
-    (CYCLONE) events in Sri Lanka. DesInventar records: 36 events with data out of
-    164 total strong wind events., Observed homes destroyed beyond habitability from
-    strong wind (STORM) events in Sri Lanka. DesInventar records: 2 events with data
-    out of 4 total strong wind events., Observed homes destroyed beyond habitability
-    from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 57 events with
-    data out of 89 total tsunami events., Observed homes destroyed beyond habitability
-    from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 538
-    events with data out of 3,697 total wildfire events., Observed homes with non-structural
-    damage, still habitable from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka.
-    DesInventar records: 7 events with data out of 40 total coastal flood events.,
-    Observed homes with non-structural damage, still habitable from convective storm
-    (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data out of
-    20 total convective storm events., Observed homes with non-structural damage,
-    still habitable from drought (DROUGHT) events in Sri Lanka. DesInventar records:
-    3 events with data out of 2,242 total drought events., Observed homes with non-structural
-    damage, still habitable from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar
-    records: 2,297 events with data out of 6,828 total flood events., Observed homes
-    with non-structural damage, still habitable from flood (RAINS) events in Sri Lanka.
-    DesInventar records: 1,829 events with data out of 2,533 total flood events.,
-    Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
-    events in Sri Lanka. DesInventar records: 1,067 events with data out of 2,100
-    total landslide events., Observed homes with non-structural damage, still habitable
-    from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 106 events
-    with data out of 164 total strong wind events., Observed homes with non-structural
-    damage, still habitable from strong wind (STORM) events in Sri Lanka. DesInventar
-    records: 2 events with data out of 4 total strong wind events., Observed homes
-    with non-structural damage, still habitable from tsunami (TSUNAMI) events in Sri
-    Lanka. DesInventar records: 57 events with data out of 89 total tsunami events.,
-    Observed homes with non-structural damage, still habitable from wildfire (FIRE,
-    FOREST FIRE) events in Sri Lanka. DesInventar records: 423 events with data out
-    of 3,697 total wildfire events., Observed persons indirectly affected (disruption
-    to services, commerce, work) from coastal flood (SURGE, TIDAL WAVE) events in
-    Sri Lanka. DesInventar records: 20 events with data out of 40 total coastal flood
-    events., Observed persons indirectly affected (disruption to services, commerce,
-    work) from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records:
-    1 events with data out of 20 total convective storm events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from drought (DROUGHT)
-    events in Sri Lanka. DesInventar records: 1,327 events with data out of 2,242
-    total drought events., Observed persons indirectly affected (disruption to services,
-    commerce, work) from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar
-    records: 5,541 events with data out of 6,828 total flood events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from flood (RAINS)
-    events in Sri Lanka. DesInventar records: 2,405 events with data out of 2,533
-    total flood events., Observed persons indirectly affected (disruption to services,
-    commerce, work) from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records:
-    1,545 events with data out of 2,100 total landslide events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from strong wind
-    (CYCLONE) events in Sri Lanka. DesInventar records: 117 events with data out of
-    164 total strong wind events., Observed persons indirectly affected (disruption
-    to services, commerce, work) from strong wind (STORM) events in Sri Lanka. DesInventar
-    records: 2 events with data out of 4 total strong wind events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from tsunami (TSUNAMI)
-    events in Sri Lanka. DesInventar records: 69 events with data out of 89 total
-    tsunami events., Observed persons indirectly affected (disruption to services,
-    commerce, work) from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar
-    records: 983 events with data out of 3,697 total wildfire events., Observed persons
-    injured or made sick directly by disaster events from convective storm (HAILSTORM)
-    events in Sri Lanka. DesInventar records: 1 events with data out of 20 total convective
-    storm events., Observed persons injured or made sick directly by disaster events
-    from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 80 events
-    with data out of 6,828 total flood events., Observed persons injured or made sick
-    directly by disaster events from flood (RAINS) events in Sri Lanka. DesInventar
-    records: 17 events with data out of 2,533 total flood events., Observed persons
-    injured or made sick directly by disaster events from landslide (LANDSLIDE) events
-    in Sri Lanka. DesInventar records: 125 events with data out of 2,100 total landslide
-    events., Observed persons injured or made sick directly by disaster events from
-    strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 16 events with
-    data out of 164 total strong wind events., Observed persons injured or made sick
-    directly by disaster events from tsunami (TSUNAMI) events in Sri Lanka. DesInventar
-    records: 40 events with data out of 89 total tsunami events., Observed persons
-    injured or made sick directly by disaster events from wildfire (FIRE, FOREST FIRE)
-    events in Sri Lanka. DesInventar records: 36 events with data out of 3,697 total
-    wildfire events., Observed persons missing or unaccounted for after disaster events
-    from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with
-    data out of 2,242 total drought events., Observed persons missing or unaccounted
-    for after disaster events from flood (FLASH FLOOD, FLOOD) events in Sri Lanka.
-    DesInventar records: 10 events with data out of 6,828 total flood events., Observed
-    persons missing or unaccounted for after disaster events from flood (RAINS) events
-    in Sri Lanka. DesInventar records: 1 events with data out of 2,533 total flood
-    events., Observed persons missing or unaccounted for after disaster events from
-    landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with
-    data out of 2,100 total landslide events., Observed persons missing or unaccounted
-    for after disaster events from strong wind (CYCLONE) events in Sri Lanka. DesInventar
-    records: 2 events with data out of 164 total strong wind events., Observed persons
-    missing or unaccounted for after disaster events from tsunami (TSUNAMI) events
-    in Sri Lanka. DesInventar records: 35 events with data out of 89 total tsunami
-    events., Observed persons permanently relocated from homes from flood (FLASH FLOOD,
-    FLOOD) events in Sri Lanka. DesInventar records: 5 events with data out of 6,828
-    total flood events., Observed persons permanently relocated from homes from flood
-    (RAINS) events in Sri Lanka. DesInventar records: 1 events with data out of 2,533
-    total flood events., Observed persons permanently relocated from homes from landslide
-    (LANDSLIDE) events in Sri Lanka. DesInventar records: 8 events with data out of
-    2,100 total landslide events., Observed persons temporarily evacuated from homes
-    or workplaces from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar
-    records: 1 events with data out of 40 total coastal flood events., Observed persons
-    temporarily evacuated from homes or workplaces from drought (DROUGHT) events in
-    Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought
-    events., Observed persons temporarily evacuated from homes or workplaces from
-    flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 82 events
-    with data out of 6,828 total flood events., Observed persons temporarily evacuated
-    from homes or workplaces from flood (RAINS) events in Sri Lanka. DesInventar records:
-    19 events with data out of 2,533 total flood events., Observed persons temporarily
-    evacuated from homes or workplaces from landslide (LANDSLIDE) events in Sri Lanka.
-    DesInventar records: 46 events with data out of 2,100 total landslide events.,
-    Observed persons temporarily evacuated from homes or workplaces from strong wind
-    (CYCLONE) events in Sri Lanka. DesInventar records: 4 events with data out of
-    164 total strong wind events., Observed persons temporarily evacuated from homes
-    or workplaces from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar
-    records: 16 events with data out of 3,697 total wildfire events., Observed persons
-    whose goods/services suffered serious damage from flood (FLASH FLOOD, FLOOD) events
-    in Sri Lanka. DesInventar records: 2 events with data out of 6,828 total flood
-    events., Observed total economic losses in local currency from flood (FLASH FLOOD,
-    FLOOD) events in Sri Lanka. DesInventar records: 7 events with data out of 6,828
-    total flood events., Observed total economic losses in local currency from landslide
-    (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with data out of
-    2,100 total landslide events., Observed total economic losses in local currency
-    from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 3 events with
-    data out of 89 total tsunami events., Observed total economic losses in local
-    currency from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records:
-    3 events with data out of 3,697 total wildfire events.'
+  description: 71 loss records across 8 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -209,6 +48,244 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 71
+  loss_groups:
+  - count: 5
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from coastal flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records:
+      20 events with data out of 40 total coastal flood events.'
+    - 'Observed deaths directly caused by disaster events from coastal flood (SURGE,
+      TIDAL WAVE) events in Sri Lanka. DesInventar records: 4 events with data out
+      of 40 total coastal flood events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from coastal
+      flood (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 1 events
+      with data out of 40 total coastal flood events.'
+    - 'Observed homes with non-structural damage, still habitable from coastal flood
+      (SURGE, TIDAL WAVE) events in Sri Lanka. DesInventar records: 7 events with
+      data out of 40 total coastal flood events.'
+    - 'Observed homes destroyed beyond habitability from coastal flood (SURGE, TIDAL
+      WAVE) events in Sri Lanka. DesInventar records: 2 events with data out of 40
+      total coastal flood events.'
+    hazard_type: coastal_flood
+  - count: 5
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from convective storm (HAILSTORM) events in Sri Lanka. DesInventar records:
+      1 events with data out of 20 total convective storm events.'
+    - 'Observed deaths directly caused by disaster events from convective storm (HAILSTORM)
+      events in Sri Lanka. DesInventar records: 1 events with data out of 20 total
+      convective storm events.'
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data
+      out of 20 total convective storm events.'
+    - 'Observed homes destroyed beyond habitability from convective storm (HAILSTORM)
+      events in Sri Lanka. DesInventar records: 1 events with data out of 20 total
+      convective storm events.'
+    - 'Observed persons injured or made sick directly by disaster events from convective
+      storm (HAILSTORM) events in Sri Lanka. DesInventar records: 1 events with data
+      out of 20 total convective storm events.'
+    hazard_type: convective_storm
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Sri Lanka. DesInventar records: 1,327 events
+      with data out of 2,242 total drought events.'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Sri Lanka. DesInventar records: 97 events with data out of 2,242 total
+      drought events.'
+    - 'Observed deaths directly caused by disaster events from drought (DROUGHT) events
+      in Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought
+      events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from drought
+      (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with data out of
+      2,242 total drought events.'
+    - 'Observed homes with non-structural damage, still habitable from drought (DROUGHT)
+      events in Sri Lanka. DesInventar records: 3 events with data out of 2,242 total
+      drought events.'
+    - 'Observed homes destroyed beyond habitability from drought (DROUGHT) events
+      in Sri Lanka. DesInventar records: 1 events with data out of 2,242 total drought
+      events.'
+    - 'Observed persons missing or unaccounted for after disaster events from drought
+      (DROUGHT) events in Sri Lanka. DesInventar records: 1 events with data out of
+      2,242 total drought events.'
+    hazard_type: drought
+  - count: 21
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 5,541
+      events with data out of 6,828 total flood events.'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLASH FLOOD,
+      FLOOD) events in Sri Lanka. DesInventar records: 5 events with data out of 6,828
+      total flood events.'
+    - 'Observed deaths directly caused by disaster events from flood (FLASH FLOOD,
+      FLOOD) events in Sri Lanka. DesInventar records: 252 events with data out of
+      6,828 total flood events.'
+    - 'Observed educational facilities destroyed or affected from flood (FLASH FLOOD,
+      FLOOD) events in Sri Lanka. DesInventar records: 2 events with data out of 6,828
+      total flood events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 82 events with
+      data out of 6,828 total flood events.'
+    - 'Observed health facilities destroyed or affected from flood (FLASH FLOOD, FLOOD)
+      events in Sri Lanka. DesInventar records: 1 events with data out of 6,828 total
+      flood events.'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLASH
+      FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 2,297 events with data
+      out of 6,828 total flood events.'
+    - 'Observed homes destroyed beyond habitability from flood (FLASH FLOOD, FLOOD)
+      events in Sri Lanka. DesInventar records: 1,229 events with data out of 6,828
+      total flood events.'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 80 events with
+      data out of 6,828 total flood events.'
+    - 'Observed total economic losses in local currency from flood (FLASH FLOOD, FLOOD)
+      events in Sri Lanka. DesInventar records: 7 events with data out of 6,828 total
+      flood events.'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLASH FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 10 events with
+      data out of 6,828 total flood events.'
+    - 'Observed persons permanently relocated from homes from flood (FLASH FLOOD,
+      FLOOD) events in Sri Lanka. DesInventar records: 5 events with data out of 6,828
+      total flood events.'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLASH
+      FLOOD, FLOOD) events in Sri Lanka. DesInventar records: 2 events with data out
+      of 6,828 total flood events.'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (RAINS) events in Sri Lanka. DesInventar records: 2,405 events with
+      data out of 2,533 total flood events.'
+    - 'Observed deaths directly caused by disaster events from flood (RAINS) events
+      in Sri Lanka. DesInventar records: 23 events with data out of 2,533 total flood
+      events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (RAINS) events in Sri Lanka. DesInventar records: 19 events with data out of
+      2,533 total flood events.'
+    - 'Observed homes with non-structural damage, still habitable from flood (RAINS)
+      events in Sri Lanka. DesInventar records: 1,829 events with data out of 2,533
+      total flood events.'
+    - 'Observed homes destroyed beyond habitability from flood (RAINS) events in Sri
+      Lanka. DesInventar records: 198 events with data out of 2,533 total flood events.'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (RAINS) events in Sri Lanka. DesInventar records: 17 events with data out of
+      2,533 total flood events.'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (RAINS) events in Sri Lanka. DesInventar records: 1 events with data out of
+      2,533 total flood events.'
+    - 'Observed persons permanently relocated from homes from flood (RAINS) events
+      in Sri Lanka. DesInventar records: 1 events with data out of 2,533 total flood
+      events.'
+    hazard_type: flood
+  - count: 9
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (LANDSLIDE) events in Sri Lanka. DesInventar records: 1,545 events
+      with data out of 2,100 total landslide events.'
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Sri Lanka. DesInventar records: 174 events with data out of 2,100
+      total landslide events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from landslide
+      (LANDSLIDE) events in Sri Lanka. DesInventar records: 46 events with data out
+      of 2,100 total landslide events.'
+    - 'Observed homes with non-structural damage, still habitable from landslide (LANDSLIDE)
+      events in Sri Lanka. DesInventar records: 1,067 events with data out of 2,100
+      total landslide events.'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Sri Lanka. DesInventar records: 316 events with data out of 2,100 total landslide
+      events.'
+    - 'Observed persons injured or made sick directly by disaster events from landslide
+      (LANDSLIDE) events in Sri Lanka. DesInventar records: 125 events with data out
+      of 2,100 total landslide events.'
+    - 'Observed total economic losses in local currency from landslide (LANDSLIDE)
+      events in Sri Lanka. DesInventar records: 4 events with data out of 2,100 total
+      landslide events.'
+    - 'Observed persons missing or unaccounted for after disaster events from landslide
+      (LANDSLIDE) events in Sri Lanka. DesInventar records: 4 events with data out
+      of 2,100 total landslide events.'
+    - 'Observed persons permanently relocated from homes from landslide (LANDSLIDE)
+      events in Sri Lanka. DesInventar records: 8 events with data out of 2,100 total
+      landslide events.'
+    hazard_type: landslide
+  - count: 10
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (STORM) events in Sri Lanka. DesInventar records: 2 events
+      with data out of 4 total strong wind events.'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (STORM) events in Sri Lanka. DesInventar records: 2 events with data out of
+      4 total strong wind events.'
+    - 'Observed homes destroyed beyond habitability from strong wind (STORM) events
+      in Sri Lanka. DesInventar records: 2 events with data out of 4 total strong
+      wind events.'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (CYCLONE) events in Sri Lanka. DesInventar records: 117 events
+      with data out of 164 total strong wind events.'
+    - 'Observed deaths directly caused by disaster events from strong wind (CYCLONE)
+      events in Sri Lanka. DesInventar records: 27 events with data out of 164 total
+      strong wind events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (CYCLONE) events in Sri Lanka. DesInventar records: 4 events with data
+      out of 164 total strong wind events.'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (CYCLONE) events in Sri Lanka. DesInventar records: 106 events with data out
+      of 164 total strong wind events.'
+    - 'Observed homes destroyed beyond habitability from strong wind (CYCLONE) events
+      in Sri Lanka. DesInventar records: 36 events with data out of 164 total strong
+      wind events.'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (CYCLONE) events in Sri Lanka. DesInventar records: 16 events with data
+      out of 164 total strong wind events.'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (CYCLONE) events in Sri Lanka. DesInventar records: 2 events with data
+      out of 164 total strong wind events.'
+    hazard_type: strong_wind
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from tsunami (TSUNAMI) events in Sri Lanka. DesInventar records: 69 events with
+      data out of 89 total tsunami events.'
+    - 'Observed deaths directly caused by disaster events from tsunami (TSUNAMI) events
+      in Sri Lanka. DesInventar records: 13 events with data out of 89 total tsunami
+      events.'
+    - 'Observed homes with non-structural damage, still habitable from tsunami (TSUNAMI)
+      events in Sri Lanka. DesInventar records: 57 events with data out of 89 total
+      tsunami events.'
+    - 'Observed homes destroyed beyond habitability from tsunami (TSUNAMI) events
+      in Sri Lanka. DesInventar records: 57 events with data out of 89 total tsunami
+      events.'
+    - 'Observed persons injured or made sick directly by disaster events from tsunami
+      (TSUNAMI) events in Sri Lanka. DesInventar records: 40 events with data out
+      of 89 total tsunami events.'
+    - 'Observed total economic losses in local currency from tsunami (TSUNAMI) events
+      in Sri Lanka. DesInventar records: 3 events with data out of 89 total tsunami
+      events.'
+    - 'Observed persons missing or unaccounted for after disaster events from tsunami
+      (TSUNAMI) events in Sri Lanka. DesInventar records: 35 events with data out
+      of 89 total tsunami events.'
+    hazard_type: tsunami
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records:
+      983 events with data out of 3,697 total wildfire events.'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Sri Lanka. DesInventar records: 61 events with data out of 3,697
+      total wildfire events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from wildfire
+      (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 16 events with
+      data out of 3,697 total wildfire events.'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Sri Lanka. DesInventar records: 423 events with data
+      out of 3,697 total wildfire events.'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Sri Lanka. DesInventar records: 538 events with data out of 3,697
+      total wildfire events.'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Sri Lanka. DesInventar records: 36 events with
+      data out of 3,697 total wildfire events.'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Sri Lanka. DesInventar records: 3 events with data out of 3,697
+      total wildfire events.'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-mdgundrr_desinventar_a.md
+++ b/_datasets/rdls_lss-mdgundrr_desinventar_a.md
@@ -35,33 +35,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from flood (FLOOD)
-    events in Madagascar. DesInventar records: 2 events with data out of 9 total flood
-    events., Observed deaths directly caused by disaster events from wildfire (FIRE)
-    events in Madagascar. DesInventar records: 14 events with data out of 218 total
-    wildfire events (2009-2009)., Observed educational facilities destroyed or affected
-    from wildfire (FIRE) events in Madagascar. DesInventar records: 9 events with
-    data out of 218 total wildfire events (2009-2009)., Observed hectares of crops/woods
-    destroyed or affected from flood (FLOOD) events in Madagascar. DesInventar records:
-    4 events with data out of 9 total flood events., Observed homes destroyed beyond
-    habitability from flood (FLOOD) events in Madagascar. DesInventar records: 4 events
-    with data out of 9 total flood events., Observed homes destroyed beyond habitability
-    from wildfire (FIRE) events in Madagascar. DesInventar records: 198 events with
-    data out of 218 total wildfire events (2009-2009)., Observed homes with non-structural
-    damage, still habitable from wildfire (FIRE) events in Madagascar. DesInventar
-    records: 1 events with data out of 218 total wildfire events (2009-2009)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from flood
-    (FLOOD) events in Madagascar. DesInventar records: 9 events with data out of 9
-    total flood events., Observed persons indirectly affected (disruption to services,
-    commerce, work) from wildfire (FIRE) events in Madagascar. DesInventar records:
-    159 events with data out of 218 total wildfire events (2009-2009)., Observed persons
-    injured or made sick directly by disaster events from wildfire (FIRE) events in
-    Madagascar. DesInventar records: 24 events with data out of 218 total wildfire
-    events (2009-2009)., Observed persons whose goods/services suffered serious damage
-    from flood (FLOOD) events in Madagascar. DesInventar records: 9 events with data
-    out of 9 total flood events., Observed persons whose goods/services suffered serious
-    damage from wildfire (FIRE) events in Madagascar. DesInventar records: 136 events
-    with data out of 218 total wildfire events (2009-2009).'
+  description: 12 loss records across 2 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -71,6 +45,49 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 12
+  loss_groups:
+  - count: 5
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Madagascar. DesInventar records: 9 events with
+      data out of 9 total flood events.'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Madagascar. DesInventar records: 4 events with data out of 9 total flood
+      events.'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Madagascar. DesInventar records: 2 events with data out of 9 total flood
+      events.'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Madagascar.
+      DesInventar records: 4 events with data out of 9 total flood events.'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Madagascar. DesInventar records: 9 events with data out of 9 total
+      flood events.'
+    hazard_type: flood
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE) events in Madagascar. DesInventar records: 159 events with
+      data out of 218 total wildfire events (2009-2009).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE) events
+      in Madagascar. DesInventar records: 14 events with data out of 218 total wildfire
+      events (2009-2009).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE)
+      events in Madagascar. DesInventar records: 9 events with data out of 218 total
+      wildfire events (2009-2009).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE)
+      events in Madagascar. DesInventar records: 1 events with data out of 218 total
+      wildfire events (2009-2009).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE) events in
+      Madagascar. DesInventar records: 198 events with data out of 218 total wildfire
+      events (2009-2009).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE) events in Madagascar. DesInventar records: 24 events with data out of
+      218 total wildfire events (2009-2009).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE) events in Madagascar. DesInventar records: 136 events with data out of
+      218 total wildfire events (2009-2009).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-mdgundrr_desinventar_b.md
+++ b/_datasets/rdls_lss-mdgundrr_desinventar_b.md
@@ -36,45 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from drought (DROUGHT)
-    events in Madagascar. DesInventar records: 3 events with data out of 3 total drought
-    events (2015-2015)., Observed deaths directly caused by disaster events from flood
-    (FLOOD) events in Madagascar. DesInventar records: 8 events with data out of 20
-    total flood events (2008-2015)., Observed deaths directly caused by disaster events
-    from landslide (LANDSLIDE) events in Madagascar. DesInventar records: 2 events
-    with data out of 2 total landslide events (2015-2015)., Observed deaths directly
-    caused by disaster events from wildfire (FIRE) events in Madagascar. DesInventar
-    records: 14 events with data out of 219 total wildfire events (2009-2015)., Observed
-    educational facilities destroyed or affected from wildfire (FIRE) events in Madagascar.
-    DesInventar records: 9 events with data out of 219 total wildfire events (2009-2015).,
-    Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
-    in Madagascar. DesInventar records: 9 events with data out of 20 total flood events
-    (2008-2015)., Observed homes destroyed beyond habitability from flood (FLOOD)
-    events in Madagascar. DesInventar records: 10 events with data out of 20 total
-    flood events (2008-2015)., Observed homes destroyed beyond habitability from landslide
-    (LANDSLIDE) events in Madagascar. DesInventar records: 2 events with data out
-    of 2 total landslide events (2015-2015)., Observed homes destroyed beyond habitability
-    from wildfire (FIRE) events in Madagascar. DesInventar records: 199 events with
-    data out of 219 total wildfire events (2009-2015)., Observed homes with non-structural
-    damage, still habitable from wildfire (FIRE) events in Madagascar. DesInventar
-    records: 1 events with data out of 219 total wildfire events (2009-2015)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from flood
-    (FLOOD) events in Madagascar. DesInventar records: 19 events with data out of
-    20 total flood events (2008-2015)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from wildfire (FIRE) events in Madagascar. DesInventar
-    records: 159 events with data out of 219 total wildfire events (2009-2015)., Observed
-    persons injured or made sick directly by disaster events from wildfire (FIRE)
-    events in Madagascar. DesInventar records: 24 events with data out of 219 total
-    wildfire events (2009-2015)., Observed persons permanently relocated from homes
-    from flood (FLOOD) events in Madagascar. DesInventar records: 7 events with data
-    out of 20 total flood events (2008-2015)., Observed persons whose goods/services
-    suffered serious damage from flood (FLOOD) events in Madagascar. DesInventar records:
-    19 events with data out of 20 total flood events (2008-2015)., Observed persons
-    whose goods/services suffered serious damage from landslide (LANDSLIDE) events
-    in Madagascar. DesInventar records: 1 events with data out of 2 total landslide
-    events (2015-2015)., Observed persons whose goods/services suffered serious damage
-    from wildfire (FIRE) events in Madagascar. DesInventar records: 137 events with
-    data out of 219 total wildfire events (2009-2015).'
+  description: 17 loss records across 4 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -84,6 +46,70 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 17
+  loss_groups:
+  - count: 1
+    descriptions:
+    - 'Observed deaths directly caused by disaster events from drought (DROUGHT) events
+      in Madagascar. DesInventar records: 3 events with data out of 3 total drought
+      events (2015-2015).'
+    hazard_type: drought
+  - count: 6
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Madagascar. DesInventar records: 19 events with
+      data out of 20 total flood events (2008-2015).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Madagascar. DesInventar records: 9 events with data out of 20 total flood
+      events (2008-2015).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Madagascar. DesInventar records: 8 events with data out of 20 total flood
+      events (2008-2015).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Madagascar.
+      DesInventar records: 10 events with data out of 20 total flood events (2008-2015).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Madagascar. DesInventar records: 7 events with data out of 20 total flood
+      events (2008-2015).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Madagascar. DesInventar records: 19 events with data out of 20 total
+      flood events (2008-2015).'
+    hazard_type: flood
+  - count: 3
+    descriptions:
+    - 'Observed deaths directly caused by disaster events from landslide (LANDSLIDE)
+      events in Madagascar. DesInventar records: 2 events with data out of 2 total
+      landslide events (2015-2015).'
+    - 'Observed homes destroyed beyond habitability from landslide (LANDSLIDE) events
+      in Madagascar. DesInventar records: 2 events with data out of 2 total landslide
+      events (2015-2015).'
+    - 'Observed persons whose goods/services suffered serious damage from landslide
+      (LANDSLIDE) events in Madagascar. DesInventar records: 1 events with data out
+      of 2 total landslide events (2015-2015).'
+    hazard_type: landslide
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE) events in Madagascar. DesInventar records: 159 events with
+      data out of 219 total wildfire events (2009-2015).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE) events
+      in Madagascar. DesInventar records: 14 events with data out of 219 total wildfire
+      events (2009-2015).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE)
+      events in Madagascar. DesInventar records: 9 events with data out of 219 total
+      wildfire events (2009-2015).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE)
+      events in Madagascar. DesInventar records: 1 events with data out of 219 total
+      wildfire events (2009-2015).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE) events in
+      Madagascar. DesInventar records: 199 events with data out of 219 total wildfire
+      events (2009-2015).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE) events in Madagascar. DesInventar records: 24 events with data out of
+      219 total wildfire events (2009-2015).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE) events in Madagascar. DesInventar records: 137 events with data out of
+      219 total wildfire events (2009-2015).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-mliundrr_desinventar.md
+++ b/_datasets/rdls_lss-mliundrr_desinventar.md
@@ -36,77 +36,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from convective
-    storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 5 events
-    with data out of 9 total convective storm events (2005-2005)., Observed deaths
-    directly caused by disaster events from flood (FLOOD) events in Mali. DesInventar
-    records: 119 events with data out of 833 total flood events., Observed educational
-    facilities destroyed or affected from flood (FLOOD) events in Mali. DesInventar
-    records: 14 events with data out of 833 total flood events., Observed hectares
-    of crops/woods destroyed or affected from flood (FLOOD) events in Mali. DesInventar
-    records: 115 events with data out of 833 total flood events., Observed hectares
-    of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events
-    in Mali. DesInventar records: 41 events with data out of 58 total wildfire events
-    (2008-2011)., Observed homes destroyed beyond habitability from convective storm
-    (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 1 events with data
-    out of 9 total convective storm events (2005-2005)., Observed homes destroyed
-    beyond habitability from flood (FLOOD) events in Mali. DesInventar records: 438
-    events with data out of 833 total flood events., Observed homes destroyed beyond
-    habitability from strong wind (WINDSTORM) events in Mali. DesInventar records:
-    1 events with data out of 2 total strong wind events., Observed homes destroyed
-    beyond habitability from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar
-    records: 2 events with data out of 58 total wildfire events (2008-2011)., Observed
-    homes with non-structural damage, still habitable from flood (FLOOD) events in
-    Mali. DesInventar records: 143 events with data out of 833 total flood events.,
-    Observed homes with non-structural damage, still habitable from wildfire (FIRE,
-    FOREST FIRE) events in Mali. DesInventar records: 2 events with data out of 58
-    total wildfire events (2008-2011)., Observed livestock lost from convective storm
-    (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 2 events with data
-    out of 9 total convective storm events (2005-2005)., Observed livestock lost from
-    drought (DROUGHT) events in Mali. DesInventar records: 2 events with data out
-    of 816 total drought events., Observed livestock lost from flood (FLOOD) events
-    in Mali. DesInventar records: 128 events with data out of 833 total flood events.,
-    Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar
-    records: 5 events with data out of 58 total wildfire events (2008-2011)., Observed
-    metres of transport networks destroyed from flood (FLOOD) events in Mali. DesInventar
-    records: 6 events with data out of 833 total flood events., Observed persons indirectly
-    affected (disruption to services, commerce, work) from convective storm (HAILSTORM,
-    THUNDERSTORM) events in Mali. DesInventar records: 2 events with data out of 9
-    total convective storm events (2005-2005)., Observed persons indirectly affected
-    (disruption to services, commerce, work) from drought (DROUGHT) events in Mali.
-    DesInventar records: 812 events with data out of 816 total drought events., Observed
-    persons indirectly affected (disruption to services, commerce, work) from flood
-    (FLOOD) events in Mali. DesInventar records: 38 events with data out of 833 total
-    flood events., Observed persons indirectly affected (disruption to services, commerce,
-    work) from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 2
-    events with data out of 58 total wildfire events (2008-2011)., Observed persons
-    injured or made sick directly by disaster events from convective storm (HAILSTORM,
-    THUNDERSTORM) events in Mali. DesInventar records: 1 events with data out of 9
-    total convective storm events (2005-2005)., Observed persons injured or made sick
-    directly by disaster events from flood (FLOOD) events in Mali. DesInventar records:
-    99 events with data out of 833 total flood events., Observed persons injured or
-    made sick directly by disaster events from strong wind (WINDSTORM) events in Mali.
-    DesInventar records: 1 events with data out of 2 total strong wind events., Observed
-    persons injured or made sick directly by disaster events from wildfire (FIRE,
-    FOREST FIRE) events in Mali. DesInventar records: 3 events with data out of 58
-    total wildfire events (2008-2011)., Observed persons missing or unaccounted for
-    after disaster events from flood (FLOOD) events in Mali. DesInventar records:
-    8 events with data out of 833 total flood events., Observed persons permanently
-    relocated from homes from flood (FLOOD) events in Mali. DesInventar records: 23
-    events with data out of 833 total flood events., Observed persons temporarily
-    evacuated from homes or workplaces from flood (FLOOD) events in Mali. DesInventar
-    records: 1 events with data out of 833 total flood events., Observed persons whose
-    goods/services suffered serious damage from drought (DROUGHT) events in Mali.
-    DesInventar records: 1 events with data out of 816 total drought events., Observed
-    persons whose goods/services suffered serious damage from flood (FLOOD) events
-    in Mali. DesInventar records: 544 events with data out of 833 total flood events.,
-    Observed persons whose goods/services suffered serious damage from strong wind
-    (WINDSTORM) events in Mali. DesInventar records: 1 events with data out of 2 total
-    strong wind events., Observed persons whose goods/services suffered serious damage
-    from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 1 events
-    with data out of 58 total wildfire events (2008-2011)., Observed total economic
-    losses in local currency from flood (FLOOD) events in Mali. DesInventar records:
-    84 events with data out of 833 total flood events.'
+  description: 32 loss records across 5 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -117,6 +47,109 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 32
+  loss_groups:
+  - count: 5
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from convective storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar
+      records: 2 events with data out of 9 total convective storm events (2005-2005).'
+    - 'Observed deaths directly caused by disaster events from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Mali. DesInventar records: 5 events with data out of
+      9 total convective storm events (2005-2005).'
+    - 'Observed homes destroyed beyond habitability from convective storm (HAILSTORM,
+      THUNDERSTORM) events in Mali. DesInventar records: 1 events with data out of
+      9 total convective storm events (2005-2005).'
+    - 'Observed persons injured or made sick directly by disaster events from convective
+      storm (HAILSTORM, THUNDERSTORM) events in Mali. DesInventar records: 1 events
+      with data out of 9 total convective storm events (2005-2005).'
+    - 'Observed livestock lost from convective storm (HAILSTORM, THUNDERSTORM) events
+      in Mali. DesInventar records: 2 events with data out of 9 total convective storm
+      events (2005-2005).'
+    hazard_type: convective_storm
+  - count: 3
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Mali. DesInventar records: 812 events with
+      data out of 816 total drought events.'
+    - 'Observed livestock lost from drought (DROUGHT) events in Mali. DesInventar
+      records: 2 events with data out of 816 total drought events.'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (DROUGHT) events in Mali. DesInventar records: 1 events with data out of 816
+      total drought events.'
+    hazard_type: drought
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Mali. DesInventar records: 38 events with data
+      out of 833 total flood events.'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Mali. DesInventar records: 115 events with data out of 833 total flood events.'
+    - 'Observed metres of transport networks destroyed from flood (FLOOD) events in
+      Mali. DesInventar records: 6 events with data out of 833 total flood events.'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Mali. DesInventar records: 119 events with data out of 833 total flood events.'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Mali. DesInventar records: 14 events with data out of 833 total flood events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLOOD) events in Mali. DesInventar records: 1 events with data out of 833 total
+      flood events.'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Mali. DesInventar records: 143 events with data out of 833 total flood
+      events.'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Mali.
+      DesInventar records: 438 events with data out of 833 total flood events.'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Mali. DesInventar records: 99 events with data out of 833
+      total flood events.'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Mali. DesInventar records: 84 events with data out of 833 total flood events.'
+    - 'Observed livestock lost from flood (FLOOD) events in Mali. DesInventar records:
+      128 events with data out of 833 total flood events.'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLOOD) events in Mali. DesInventar records: 8 events with data out of 833 total
+      flood events.'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Mali. DesInventar records: 23 events with data out of 833 total flood events.'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Mali. DesInventar records: 544 events with data out of 833 total flood
+      events.'
+    hazard_type: flood
+  - count: 3
+    descriptions:
+    - 'Observed homes destroyed beyond habitability from strong wind (WINDSTORM) events
+      in Mali. DesInventar records: 1 events with data out of 2 total strong wind
+      events.'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (WINDSTORM) events in Mali. DesInventar records: 1 events with data out
+      of 2 total strong wind events.'
+    - 'Observed persons whose goods/services suffered serious damage from strong wind
+      (WINDSTORM) events in Mali. DesInventar records: 1 events with data out of 2
+      total strong wind events.'
+    hazard_type: strong_wind
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar records: 2 events
+      with data out of 58 total wildfire events (2008-2011).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Mali. DesInventar records: 41 events with data out of
+      58 total wildfire events (2008-2011).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Mali. DesInventar records: 2 events with data out of
+      58 total wildfire events (2008-2011).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Mali. DesInventar records: 2 events with data out of 58 total wildfire
+      events (2008-2011).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE, FOREST FIRE) events in Mali. DesInventar records: 3 events with data
+      out of 58 total wildfire events (2008-2011).'
+    - 'Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Mali. DesInventar
+      records: 5 events with data out of 58 total wildfire events (2008-2011).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE, FOREST FIRE) events in Mali. DesInventar records: 1 events with data
+      out of 58 total wildfire events (2008-2011).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-nerundrr_desinventar_a.md
+++ b/_datasets/rdls_lss-nerundrr_desinventar_a.md
@@ -34,68 +34,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from drought (DROUGHT)
-    events in Niger. DesInventar records: 2 events with data out of 289 total drought
-    events., Observed deaths directly caused by disaster events from flood (FLOOD)
-    events in Niger. DesInventar records: 49 events with data out of 763 total flood
-    events., Observed deaths directly caused by disaster events from wildfire (FIRE,
-    FOREST FIRE) events in Niger. DesInventar records: 23 events with data out of
-    310 total wildfire events., Observed educational facilities destroyed or affected
-    from flood (FLOOD) events in Niger. DesInventar records: 5 events with data out
-    of 763 total flood events., Observed educational facilities destroyed or affected
-    from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 2 events
-    with data out of 310 total wildfire events., Observed health facilities destroyed
-    or affected from flood (FLOOD) events in Niger. DesInventar records: 1 events
-    with data out of 763 total flood events., Observed hectares of crops/woods destroyed
-    or affected from drought (DROUGHT) events in Niger. DesInventar records: 15 events
-    with data out of 289 total drought events., Observed hectares of crops/woods destroyed
-    or affected from flood (FLOOD) events in Niger. DesInventar records: 239 events
-    with data out of 763 total flood events., Observed hectares of crops/woods destroyed
-    or affected from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records:
-    168 events with data out of 310 total wildfire events., Observed homes destroyed
-    beyond habitability from flood (FLOOD) events in Niger. DesInventar records: 410
-    events with data out of 763 total flood events., Observed homes destroyed beyond
-    habitability from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records:
-    28 events with data out of 310 total wildfire events., Observed homes with non-structural
-    damage, still habitable from flood (FLOOD) events in Niger. DesInventar records:
-    29 events with data out of 763 total flood events., Observed homes with non-structural
-    damage, still habitable from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
-    records: 2 events with data out of 310 total wildfire events., Observed livestock
-    lost from drought (DROUGHT) events in Niger. DesInventar records: 14 events with
-    data out of 289 total drought events., Observed livestock lost from flood (FLOOD)
-    events in Niger. DesInventar records: 122 events with data out of 763 total flood
-    events., Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger.
-    DesInventar records: 14 events with data out of 310 total wildfire events., Observed
-    persons indirectly affected (disruption to services, commerce, work) from drought
-    (DROUGHT) events in Niger. DesInventar records: 46 events with data out of 289
-    total drought events., Observed persons indirectly affected (disruption to services,
-    commerce, work) from flood (FLOOD) events in Niger. DesInventar records: 214 events
-    with data out of 763 total flood events., Observed persons indirectly affected
-    (disruption to services, commerce, work) from wildfire (FIRE, FOREST FIRE) events
-    in Niger. DesInventar records: 78 events with data out of 310 total wildfire events.,
-    Observed persons injured or made sick directly by disaster events from flood (FLOOD)
-    events in Niger. DesInventar records: 34 events with data out of 763 total flood
-    events., Observed persons permanently relocated from homes from drought (DROUGHT)
-    events in Niger. DesInventar records: 10 events with data out of 289 total drought
-    events., Observed persons permanently relocated from homes from flood (FLOOD)
-    events in Niger. DesInventar records: 2 events with data out of 763 total flood
-    events., Observed persons whose goods/services suffered serious damage from drought
-    (DROUGHT) events in Niger. DesInventar records: 143 events with data out of 289
-    total drought events., Observed persons whose goods/services suffered serious
-    damage from flood (FLOOD) events in Niger. DesInventar records: 456 events with
-    data out of 763 total flood events., Observed persons whose goods/services suffered
-    serious damage from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
-    records: 48 events with data out of 310 total wildfire events., Observed total
-    economic losses in US Dollars from flood (FLOOD) events in Niger. DesInventar
-    records: 1 events with data out of 763 total flood events., Observed total economic
-    losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
-    records: 2 events with data out of 310 total wildfire events., Observed total
-    economic losses in local currency from drought (DROUGHT) events in Niger. DesInventar
-    records: 6 events with data out of 289 total drought events., Observed total economic
-    losses in local currency from flood (FLOOD) events in Niger. DesInventar records:
-    9 events with data out of 763 total flood events., Observed total economic losses
-    in local currency from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
-    records: 14 events with data out of 310 total wildfire events.'
+  description: 30 loss records across 3 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -105,6 +44,94 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 30
+  loss_groups:
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Niger. DesInventar records: 46 events with
+      data out of 289 total drought events.'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Niger. DesInventar records: 15 events with data out of 289 total drought
+      events.'
+    - 'Observed deaths directly caused by disaster events from drought (DROUGHT) events
+      in Niger. DesInventar records: 2 events with data out of 289 total drought events.'
+    - 'Observed total economic losses in local currency from drought (DROUGHT) events
+      in Niger. DesInventar records: 6 events with data out of 289 total drought events.'
+    - 'Observed livestock lost from drought (DROUGHT) events in Niger. DesInventar
+      records: 14 events with data out of 289 total drought events.'
+    - 'Observed persons permanently relocated from homes from drought (DROUGHT) events
+      in Niger. DesInventar records: 10 events with data out of 289 total drought
+      events.'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (DROUGHT) events in Niger. DesInventar records: 143 events with data out of
+      289 total drought events.'
+    hazard_type: drought
+  - count: 13
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Niger. DesInventar records: 214 events with data
+      out of 763 total flood events.'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Niger. DesInventar records: 239 events with data out of 763 total flood events.'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Niger. DesInventar records: 49 events with data out of 763 total flood events.'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Niger. DesInventar records: 5 events with data out of 763 total flood events.'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Niger. DesInventar records: 1 events with data out of 763 total flood events.'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Niger. DesInventar records: 29 events with data out of 763 total flood
+      events.'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Niger.
+      DesInventar records: 410 events with data out of 763 total flood events.'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Niger. DesInventar records: 34 events with data out of 763
+      total flood events.'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Niger. DesInventar records: 9 events with data out of 763 total flood events.'
+    - 'Observed total economic losses in US Dollars from flood (FLOOD) events in Niger.
+      DesInventar records: 1 events with data out of 763 total flood events.'
+    - 'Observed livestock lost from flood (FLOOD) events in Niger. DesInventar records:
+      122 events with data out of 763 total flood events.'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Niger. DesInventar records: 2 events with data out of 763 total flood events.'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Niger. DesInventar records: 456 events with data out of 763 total
+      flood events.'
+    hazard_type: flood
+  - count: 10
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 78 events
+      with data out of 310 total wildfire events.'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Niger. DesInventar records: 168 events with data out
+      of 310 total wildfire events.'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Niger. DesInventar records: 23 events with data out of 310 total
+      wildfire events.'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of
+      310 total wildfire events.'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of
+      310 total wildfire events.'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Niger. DesInventar records: 28 events with data out of 310 total wildfire
+      events.'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Niger. DesInventar records: 14 events with data out of 310 total
+      wildfire events.'
+    - 'Observed total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE)
+      events in Niger. DesInventar records: 2 events with data out of 310 total wildfire
+      events.'
+    - 'Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger.
+      DesInventar records: 14 events with data out of 310 total wildfire events.'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE, FOREST FIRE) events in Niger. DesInventar records: 48 events with data
+      out of 310 total wildfire events.'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-nerundrr_desinventar_b.md
+++ b/_datasets/rdls_lss-nerundrr_desinventar_b.md
@@ -34,73 +34,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from drought (DROUGHT)
-    events in Niger. DesInventar records: 2 events with data out of 289 total drought
-    events (1998-2005)., Observed deaths directly caused by disaster events from flood
-    (FLOOD) events in Niger. DesInventar records: 49 events with data out of 765 total
-    flood events (1990-2012)., Observed deaths directly caused by disaster events
-    from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 23 events
-    with data out of 310 total wildfire events (1992-2013)., Observed educational
-    facilities destroyed or affected from flood (FLOOD) events in Niger. DesInventar
-    records: 5 events with data out of 765 total flood events (1990-2012)., Observed
-    educational facilities destroyed or affected from wildfire (FIRE, FOREST FIRE)
-    events in Niger. DesInventar records: 2 events with data out of 310 total wildfire
-    events (1992-2013)., Observed health facilities destroyed or affected from flood
-    (FLOOD) events in Niger. DesInventar records: 1 events with data out of 765 total
-    flood events (1990-2012)., Observed hectares of crops/woods destroyed or affected
-    from drought (DROUGHT) events in Niger. DesInventar records: 15 events with data
-    out of 289 total drought events (1998-2005)., Observed hectares of crops/woods
-    destroyed or affected from flood (FLOOD) events in Niger. DesInventar records:
-    239 events with data out of 765 total flood events (1990-2012)., Observed hectares
-    of crops/woods destroyed or affected from wildfire (FIRE, FOREST FIRE) events
-    in Niger. DesInventar records: 168 events with data out of 310 total wildfire
-    events (1992-2013)., Observed homes destroyed beyond habitability from flood (FLOOD)
-    events in Niger. DesInventar records: 412 events with data out of 765 total flood
-    events (1990-2012)., Observed homes destroyed beyond habitability from wildfire
-    (FIRE, FOREST FIRE) events in Niger. DesInventar records: 28 events with data
-    out of 310 total wildfire events (1992-2013)., Observed homes with non-structural
-    damage, still habitable from flood (FLOOD) events in Niger. DesInventar records:
-    29 events with data out of 765 total flood events (1990-2012)., Observed homes
-    with non-structural damage, still habitable from wildfire (FIRE, FOREST FIRE)
-    events in Niger. DesInventar records: 2 events with data out of 310 total wildfire
-    events (1992-2013)., Observed livestock lost from drought (DROUGHT) events in
-    Niger. DesInventar records: 14 events with data out of 289 total drought events
-    (1998-2005)., Observed livestock lost from flood (FLOOD) events in Niger. DesInventar
-    records: 122 events with data out of 765 total flood events (1990-2012)., Observed
-    livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
-    records: 14 events with data out of 310 total wildfire events (1992-2013)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from drought
-    (DROUGHT) events in Niger. DesInventar records: 46 events with data out of 289
-    total drought events (1998-2005)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from flood (FLOOD) events in Niger. DesInventar records:
-    216 events with data out of 765 total flood events (1990-2012)., Observed persons
-    indirectly affected (disruption to services, commerce, work) from wildfire (FIRE,
-    FOREST FIRE) events in Niger. DesInventar records: 78 events with data out of
-    310 total wildfire events (1992-2013)., Observed persons injured or made sick
-    directly by disaster events from flood (FLOOD) events in Niger. DesInventar records:
-    34 events with data out of 765 total flood events (1990-2012)., Observed persons
-    permanently relocated from homes from drought (DROUGHT) events in Niger. DesInventar
-    records: 10 events with data out of 289 total drought events (1998-2005)., Observed
-    persons permanently relocated from homes from flood (FLOOD) events in Niger. DesInventar
-    records: 2 events with data out of 765 total flood events (1990-2012)., Observed
-    persons whose goods/services suffered serious damage from drought (DROUGHT) events
-    in Niger. DesInventar records: 143 events with data out of 289 total drought events
-    (1998-2005)., Observed persons whose goods/services suffered serious damage from
-    flood (FLOOD) events in Niger. DesInventar records: 458 events with data out of
-    765 total flood events (1990-2012)., Observed persons whose goods/services suffered
-    serious damage from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar
-    records: 48 events with data out of 310 total wildfire events (1992-2013)., Observed
-    total economic losses in US Dollars from flood (FLOOD) events in Niger. DesInventar
-    records: 1 events with data out of 765 total flood events (1990-2012)., Observed
-    total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE) events in
-    Niger. DesInventar records: 2 events with data out of 310 total wildfire events
-    (1992-2013)., Observed total economic losses in local currency from drought (DROUGHT)
-    events in Niger. DesInventar records: 6 events with data out of 289 total drought
-    events (1998-2005)., Observed total economic losses in local currency from flood
-    (FLOOD) events in Niger. DesInventar records: 11 events with data out of 765 total
-    flood events (1990-2012)., Observed total economic losses in local currency from
-    wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 14 events with
-    data out of 310 total wildfire events (1992-2013).'
+  description: 30 loss records across 3 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -110,6 +44,102 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 30
+  loss_groups:
+  - count: 7
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from drought (DROUGHT) events in Niger. DesInventar records: 46 events with
+      data out of 289 total drought events (1998-2005).'
+    - 'Observed hectares of crops/woods destroyed or affected from drought (DROUGHT)
+      events in Niger. DesInventar records: 15 events with data out of 289 total drought
+      events (1998-2005).'
+    - 'Observed deaths directly caused by disaster events from drought (DROUGHT) events
+      in Niger. DesInventar records: 2 events with data out of 289 total drought events
+      (1998-2005).'
+    - 'Observed total economic losses in local currency from drought (DROUGHT) events
+      in Niger. DesInventar records: 6 events with data out of 289 total drought events
+      (1998-2005).'
+    - 'Observed livestock lost from drought (DROUGHT) events in Niger. DesInventar
+      records: 14 events with data out of 289 total drought events (1998-2005).'
+    - 'Observed persons permanently relocated from homes from drought (DROUGHT) events
+      in Niger. DesInventar records: 10 events with data out of 289 total drought
+      events (1998-2005).'
+    - 'Observed persons whose goods/services suffered serious damage from drought
+      (DROUGHT) events in Niger. DesInventar records: 143 events with data out of
+      289 total drought events (1998-2005).'
+    hazard_type: drought
+  - count: 13
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Niger. DesInventar records: 216 events with data
+      out of 765 total flood events (1990-2012).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Niger. DesInventar records: 239 events with data out of 765 total flood events
+      (1990-2012).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Niger. DesInventar records: 49 events with data out of 765 total flood events
+      (1990-2012).'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Niger. DesInventar records: 5 events with data out of 765 total flood events
+      (1990-2012).'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Niger. DesInventar records: 1 events with data out of 765 total flood events
+      (1990-2012).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Niger. DesInventar records: 29 events with data out of 765 total flood
+      events (1990-2012).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Niger.
+      DesInventar records: 412 events with data out of 765 total flood events (1990-2012).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Niger. DesInventar records: 34 events with data out of 765
+      total flood events (1990-2012).'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Niger. DesInventar records: 11 events with data out of 765 total flood events
+      (1990-2012).'
+    - 'Observed total economic losses in US Dollars from flood (FLOOD) events in Niger.
+      DesInventar records: 1 events with data out of 765 total flood events (1990-2012).'
+    - 'Observed livestock lost from flood (FLOOD) events in Niger. DesInventar records:
+      122 events with data out of 765 total flood events (1990-2012).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Niger. DesInventar records: 2 events with data out of 765 total flood events
+      (1990-2012).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Niger. DesInventar records: 458 events with data out of 765 total
+      flood events (1990-2012).'
+    hazard_type: flood
+  - count: 10
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE, FOREST FIRE) events in Niger. DesInventar records: 78 events
+      with data out of 310 total wildfire events (1992-2013).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Niger. DesInventar records: 168 events with data out
+      of 310 total wildfire events (1992-2013).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE, FOREST
+      FIRE) events in Niger. DesInventar records: 23 events with data out of 310 total
+      wildfire events (1992-2013).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE,
+      FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of
+      310 total wildfire events (1992-2013).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE,
+      FOREST FIRE) events in Niger. DesInventar records: 2 events with data out of
+      310 total wildfire events (1992-2013).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE, FOREST FIRE)
+      events in Niger. DesInventar records: 28 events with data out of 310 total wildfire
+      events (1992-2013).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE, FOREST
+      FIRE) events in Niger. DesInventar records: 14 events with data out of 310 total
+      wildfire events (1992-2013).'
+    - 'Observed total economic losses in US Dollars from wildfire (FIRE, FOREST FIRE)
+      events in Niger. DesInventar records: 2 events with data out of 310 total wildfire
+      events (1992-2013).'
+    - 'Observed livestock lost from wildfire (FIRE, FOREST FIRE) events in Niger.
+      DesInventar records: 14 events with data out of 310 total wildfire events (1992-2013).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE, FOREST FIRE) events in Niger. DesInventar records: 48 events with data
+      out of 310 total wildfire events (1992-2013).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-senundrr_desinventar_a.md
+++ b/_datasets/rdls_lss-senundrr_desinventar_a.md
@@ -35,67 +35,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from flood (FLOOD)
-    events in Senegal. DesInventar records: 22 events with data out of 149 total flood
-    events., Observed deaths directly caused by disaster events from strong wind (STORM)
-    events in Senegal. DesInventar records: 2 events with data out of 13 total strong
-    wind events., Observed deaths directly caused by disaster events from wildfire
-    (FIRE) events in Senegal. DesInventar records: 50 events with data out of 580
-    total wildfire events., Observed educational facilities destroyed or affected
-    from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data
-    out of 149 total flood events., Observed educational facilities destroyed or affected
-    from wildfire (FIRE) events in Senegal. DesInventar records: 17 events with data
-    out of 580 total wildfire events., Observed health facilities destroyed or affected
-    from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data
-    out of 149 total flood events., Observed health facilities destroyed or affected
-    from wildfire (FIRE) events in Senegal. DesInventar records: 3 events with data
-    out of 580 total wildfire events., Observed hectares of crops/woods destroyed
-    or affected from flood (FLOOD) events in Senegal. DesInventar records: 14 events
-    with data out of 149 total flood events., Observed hectares of crops/woods destroyed
-    or affected from wildfire (FIRE) events in Senegal. DesInventar records: 1 events
-    with data out of 580 total wildfire events., Observed homes destroyed beyond habitability
-    from flood (FLOOD) events in Senegal. DesInventar records: 8 events with data
-    out of 149 total flood events., Observed homes destroyed beyond habitability from
-    wildfire (FIRE) events in Senegal. DesInventar records: 16 events with data out
-    of 580 total wildfire events., Observed homes with non-structural damage, still
-    habitable from flood (FLOOD) events in Senegal. DesInventar records: 45 events
-    with data out of 149 total flood events., Observed homes with non-structural damage,
-    still habitable from wildfire (FIRE) events in Senegal. DesInventar records: 204
-    events with data out of 580 total wildfire events., Observed livestock lost from
-    wildfire (FIRE) events in Senegal. DesInventar records: 5 events with data out
-    of 580 total wildfire events., Observed persons indirectly affected (disruption
-    to services, commerce, work) from flood (FLOOD) events in Senegal. DesInventar
-    records: 18 events with data out of 149 total flood events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from wildfire (FIRE)
-    events in Senegal. DesInventar records: 4 events with data out of 580 total wildfire
-    events., Observed persons injured or made sick directly by disaster events from
-    flood (FLOOD) events in Senegal. DesInventar records: 12 events with data out
-    of 149 total flood events., Observed persons injured or made sick directly by
-    disaster events from wildfire (FIRE) events in Senegal. DesInventar records: 29
-    events with data out of 580 total wildfire events., Observed persons missing or
-    unaccounted for after disaster events from flood (FLOOD) events in Senegal. DesInventar
-    records: 4 events with data out of 149 total flood events., Observed persons missing
-    or unaccounted for after disaster events from strong wind (STORM) events in Senegal.
-    DesInventar records: 11 events with data out of 13 total strong wind events.,
-    Observed persons permanently relocated from homes from flood (FLOOD) events in
-    Senegal. DesInventar records: 3 events with data out of 149 total flood events.,
-    Observed persons temporarily evacuated from homes or workplaces from flood (FLOOD)
-    events in Senegal. DesInventar records: 2 events with data out of 149 total flood
-    events., Observed persons temporarily evacuated from homes or workplaces from
-    strong wind (STORM) events in Senegal. DesInventar records: 7 events with data
-    out of 13 total strong wind events., Observed persons whose goods/services suffered
-    serious damage from flood (FLOOD) events in Senegal. DesInventar records: 16 events
-    with data out of 149 total flood events., Observed persons whose goods/services
-    suffered serious damage from wildfire (FIRE) events in Senegal. DesInventar records:
-    25 events with data out of 580 total wildfire events., Observed total economic
-    losses in US Dollars from flood (FLOOD) events in Senegal. DesInventar records:
-    2 events with data out of 149 total flood events., Observed total economic losses
-    in US Dollars from wildfire (FIRE) events in Senegal. DesInventar records: 59
-    events with data out of 580 total wildfire events., Observed total economic losses
-    in local currency from flood (FLOOD) events in Senegal. DesInventar records: 3
-    events with data out of 149 total flood events., Observed total economic losses
-    in local currency from wildfire (FIRE) events in Senegal. DesInventar records:
-    2 events with data out of 580 total wildfire events.'
+  description: 29 loss records across 3 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -105,6 +45,97 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 29
+  loss_groups:
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Senegal. DesInventar records: 18 events with data
+      out of 149 total flood events.'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Senegal. DesInventar records: 14 events with data out of 149 total flood
+      events.'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Senegal. DesInventar records: 22 events with data out of 149 total flood
+      events.'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Senegal. DesInventar records: 2 events with data out of 149 total flood events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149
+      total flood events.'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Senegal. DesInventar records: 2 events with data out of 149 total flood events.'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Senegal. DesInventar records: 45 events with data out of 149 total
+      flood events.'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Senegal.
+      DesInventar records: 8 events with data out of 149 total flood events.'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Senegal. DesInventar records: 12 events with data out of 149
+      total flood events.'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Senegal. DesInventar records: 3 events with data out of 149 total flood events.'
+    - 'Observed total economic losses in US Dollars from flood (FLOOD) events in Senegal.
+      DesInventar records: 2 events with data out of 149 total flood events.'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLOOD) events in Senegal. DesInventar records: 4 events with data out of 149
+      total flood events.'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Senegal. DesInventar records: 3 events with data out of 149 total flood events.'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Senegal. DesInventar records: 16 events with data out of 149 total
+      flood events.'
+    hazard_type: flood
+  - count: 3
+    descriptions:
+    - 'Observed deaths directly caused by disaster events from strong wind (STORM)
+      events in Senegal. DesInventar records: 2 events with data out of 13 total strong
+      wind events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (STORM) events in Senegal. DesInventar records: 7 events with data out
+      of 13 total strong wind events.'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (STORM) events in Senegal. DesInventar records: 11 events with data out
+      of 13 total strong wind events.'
+    hazard_type: strong_wind
+  - count: 12
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE) events in Senegal. DesInventar records: 4 events with data
+      out of 580 total wildfire events.'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE)
+      events in Senegal. DesInventar records: 1 events with data out of 580 total
+      wildfire events.'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE) events
+      in Senegal. DesInventar records: 50 events with data out of 580 total wildfire
+      events.'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE)
+      events in Senegal. DesInventar records: 17 events with data out of 580 total
+      wildfire events.'
+    - 'Observed health facilities destroyed or affected from wildfire (FIRE) events
+      in Senegal. DesInventar records: 3 events with data out of 580 total wildfire
+      events.'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE)
+      events in Senegal. DesInventar records: 204 events with data out of 580 total
+      wildfire events.'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE) events in
+      Senegal. DesInventar records: 16 events with data out of 580 total wildfire
+      events.'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE) events in Senegal. DesInventar records: 29 events with data out of 580
+      total wildfire events.'
+    - 'Observed total economic losses in local currency from wildfire (FIRE) events
+      in Senegal. DesInventar records: 2 events with data out of 580 total wildfire
+      events.'
+    - 'Observed total economic losses in US Dollars from wildfire (FIRE) events in
+      Senegal. DesInventar records: 59 events with data out of 580 total wildfire
+      events.'
+    - 'Observed livestock lost from wildfire (FIRE) events in Senegal. DesInventar
+      records: 5 events with data out of 580 total wildfire events.'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE) events in Senegal. DesInventar records: 25 events with data out of 580
+      total wildfire events.'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-senundrr_desinventar_b.md
+++ b/_datasets/rdls_lss-senundrr_desinventar_b.md
@@ -35,71 +35,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from flood (FLOOD)
-    events in Senegal. DesInventar records: 22 events with data out of 149 total flood
-    events (2008-2010)., Observed deaths directly caused by disaster events from strong
-    wind (STORM) events in Senegal. DesInventar records: 2 events with data out of
-    13 total strong wind events (2013-2014)., Observed deaths directly caused by disaster
-    events from wildfire (FIRE) events in Senegal. DesInventar records: 50 events
-    with data out of 580 total wildfire events (2010-2014)., Observed educational
-    facilities destroyed or affected from flood (FLOOD) events in Senegal. DesInventar
-    records: 2 events with data out of 149 total flood events (2008-2010)., Observed
-    educational facilities destroyed or affected from wildfire (FIRE) events in Senegal.
-    DesInventar records: 17 events with data out of 580 total wildfire events (2010-2014).,
-    Observed health facilities destroyed or affected from flood (FLOOD) events in
-    Senegal. DesInventar records: 2 events with data out of 149 total flood events
-    (2008-2010)., Observed health facilities destroyed or affected from wildfire (FIRE)
-    events in Senegal. DesInventar records: 3 events with data out of 580 total wildfire
-    events (2010-2014)., Observed hectares of crops/woods destroyed or affected from
-    flood (FLOOD) events in Senegal. DesInventar records: 14 events with data out
-    of 149 total flood events (2008-2010)., Observed hectares of crops/woods destroyed
-    or affected from wildfire (FIRE) events in Senegal. DesInventar records: 1 events
-    with data out of 580 total wildfire events (2010-2014)., Observed homes destroyed
-    beyond habitability from flood (FLOOD) events in Senegal. DesInventar records:
-    8 events with data out of 149 total flood events (2008-2010)., Observed homes
-    destroyed beyond habitability from wildfire (FIRE) events in Senegal. DesInventar
-    records: 16 events with data out of 580 total wildfire events (2010-2014)., Observed
-    homes with non-structural damage, still habitable from flood (FLOOD) events in
-    Senegal. DesInventar records: 45 events with data out of 149 total flood events
-    (2008-2010)., Observed homes with non-structural damage, still habitable from
-    wildfire (FIRE) events in Senegal. DesInventar records: 204 events with data out
-    of 580 total wildfire events (2010-2014)., Observed livestock lost from wildfire
-    (FIRE) events in Senegal. DesInventar records: 5 events with data out of 580 total
-    wildfire events (2010-2014)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from flood (FLOOD) events in Senegal. DesInventar
-    records: 18 events with data out of 149 total flood events (2008-2010)., Observed
-    persons indirectly affected (disruption to services, commerce, work) from wildfire
-    (FIRE) events in Senegal. DesInventar records: 4 events with data out of 580 total
-    wildfire events (2010-2014)., Observed persons injured or made sick directly by
-    disaster events from flood (FLOOD) events in Senegal. DesInventar records: 12
-    events with data out of 149 total flood events (2008-2010)., Observed persons
-    injured or made sick directly by disaster events from wildfire (FIRE) events in
-    Senegal. DesInventar records: 29 events with data out of 580 total wildfire events
-    (2010-2014)., Observed persons missing or unaccounted for after disaster events
-    from flood (FLOOD) events in Senegal. DesInventar records: 4 events with data
-    out of 149 total flood events (2008-2010)., Observed persons missing or unaccounted
-    for after disaster events from strong wind (STORM) events in Senegal. DesInventar
-    records: 11 events with data out of 13 total strong wind events (2013-2014).,
-    Observed persons permanently relocated from homes from flood (FLOOD) events in
-    Senegal. DesInventar records: 3 events with data out of 149 total flood events
-    (2008-2010)., Observed persons temporarily evacuated from homes or workplaces
-    from flood (FLOOD) events in Senegal. DesInventar records: 2 events with data
-    out of 149 total flood events (2008-2010)., Observed persons temporarily evacuated
-    from homes or workplaces from strong wind (STORM) events in Senegal. DesInventar
-    records: 7 events with data out of 13 total strong wind events (2013-2014)., Observed
-    persons whose goods/services suffered serious damage from flood (FLOOD) events
-    in Senegal. DesInventar records: 16 events with data out of 149 total flood events
-    (2008-2010)., Observed persons whose goods/services suffered serious damage from
-    wildfire (FIRE) events in Senegal. DesInventar records: 25 events with data out
-    of 580 total wildfire events (2010-2014)., Observed total economic losses in US
-    Dollars from flood (FLOOD) events in Senegal. DesInventar records: 2 events with
-    data out of 149 total flood events (2008-2010)., Observed total economic losses
-    in US Dollars from wildfire (FIRE) events in Senegal. DesInventar records: 59
-    events with data out of 580 total wildfire events (2010-2014)., Observed total
-    economic losses in local currency from flood (FLOOD) events in Senegal. DesInventar
-    records: 3 events with data out of 149 total flood events (2008-2010)., Observed
-    total economic losses in local currency from wildfire (FIRE) events in Senegal.
-    DesInventar records: 2 events with data out of 580 total wildfire events (2010-2014).'
+  description: 29 loss records across 3 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -109,6 +45,101 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 29
+  loss_groups:
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (FLOOD) events in Senegal. DesInventar records: 18 events with data
+      out of 149 total flood events (2008-2010).'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (FLOOD) events
+      in Senegal. DesInventar records: 14 events with data out of 149 total flood
+      events (2008-2010).'
+    - 'Observed deaths directly caused by disaster events from flood (FLOOD) events
+      in Senegal. DesInventar records: 22 events with data out of 149 total flood
+      events (2008-2010).'
+    - 'Observed educational facilities destroyed or affected from flood (FLOOD) events
+      in Senegal. DesInventar records: 2 events with data out of 149 total flood events
+      (2008-2010).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (FLOOD) events in Senegal. DesInventar records: 2 events with data out of 149
+      total flood events (2008-2010).'
+    - 'Observed health facilities destroyed or affected from flood (FLOOD) events
+      in Senegal. DesInventar records: 2 events with data out of 149 total flood events
+      (2008-2010).'
+    - 'Observed homes with non-structural damage, still habitable from flood (FLOOD)
+      events in Senegal. DesInventar records: 45 events with data out of 149 total
+      flood events (2008-2010).'
+    - 'Observed homes destroyed beyond habitability from flood (FLOOD) events in Senegal.
+      DesInventar records: 8 events with data out of 149 total flood events (2008-2010).'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (FLOOD) events in Senegal. DesInventar records: 12 events with data out of 149
+      total flood events (2008-2010).'
+    - 'Observed total economic losses in local currency from flood (FLOOD) events
+      in Senegal. DesInventar records: 3 events with data out of 149 total flood events
+      (2008-2010).'
+    - 'Observed total economic losses in US Dollars from flood (FLOOD) events in Senegal.
+      DesInventar records: 2 events with data out of 149 total flood events (2008-2010).'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (FLOOD) events in Senegal. DesInventar records: 4 events with data out of 149
+      total flood events (2008-2010).'
+    - 'Observed persons permanently relocated from homes from flood (FLOOD) events
+      in Senegal. DesInventar records: 3 events with data out of 149 total flood events
+      (2008-2010).'
+    - 'Observed persons whose goods/services suffered serious damage from flood (FLOOD)
+      events in Senegal. DesInventar records: 16 events with data out of 149 total
+      flood events (2008-2010).'
+    hazard_type: flood
+  - count: 3
+    descriptions:
+    - 'Observed deaths directly caused by disaster events from strong wind (STORM)
+      events in Senegal. DesInventar records: 2 events with data out of 13 total strong
+      wind events (2013-2014).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (STORM) events in Senegal. DesInventar records: 7 events with data out
+      of 13 total strong wind events (2013-2014).'
+    - 'Observed persons missing or unaccounted for after disaster events from strong
+      wind (STORM) events in Senegal. DesInventar records: 11 events with data out
+      of 13 total strong wind events (2013-2014).'
+    hazard_type: strong_wind
+  - count: 12
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (FIRE) events in Senegal. DesInventar records: 4 events with data
+      out of 580 total wildfire events (2010-2014).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (FIRE)
+      events in Senegal. DesInventar records: 1 events with data out of 580 total
+      wildfire events (2010-2014).'
+    - 'Observed deaths directly caused by disaster events from wildfire (FIRE) events
+      in Senegal. DesInventar records: 50 events with data out of 580 total wildfire
+      events (2010-2014).'
+    - 'Observed educational facilities destroyed or affected from wildfire (FIRE)
+      events in Senegal. DesInventar records: 17 events with data out of 580 total
+      wildfire events (2010-2014).'
+    - 'Observed health facilities destroyed or affected from wildfire (FIRE) events
+      in Senegal. DesInventar records: 3 events with data out of 580 total wildfire
+      events (2010-2014).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (FIRE)
+      events in Senegal. DesInventar records: 204 events with data out of 580 total
+      wildfire events (2010-2014).'
+    - 'Observed homes destroyed beyond habitability from wildfire (FIRE) events in
+      Senegal. DesInventar records: 16 events with data out of 580 total wildfire
+      events (2010-2014).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (FIRE) events in Senegal. DesInventar records: 29 events with data out of 580
+      total wildfire events (2010-2014).'
+    - 'Observed total economic losses in local currency from wildfire (FIRE) events
+      in Senegal. DesInventar records: 2 events with data out of 580 total wildfire
+      events (2010-2014).'
+    - 'Observed total economic losses in US Dollars from wildfire (FIRE) events in
+      Senegal. DesInventar records: 59 events with data out of 580 total wildfire
+      events (2010-2014).'
+    - 'Observed livestock lost from wildfire (FIRE) events in Senegal. DesInventar
+      records: 5 events with data out of 580 total wildfire events (2010-2014).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (FIRE) events in Senegal. DesInventar records: 25 events with data out of 580
+      total wildfire events (2010-2014).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_lss-tgoundrr_desinventar.md
+++ b/_datasets/rdls_lss-tgoundrr_desinventar.md
@@ -34,122 +34,7 @@ loss:
   approach: ''
   base_data_type: ''
   category: ''
-  description: 'Observed deaths directly caused by disaster events from convective
-    storm (Thunderstorm) events in Togo. DesInventar records: 1 events with data out
-    of 9 total convective storm events (2011-2011)., Observed deaths directly caused
-    by disaster events from flood (Flood) events in Togo. DesInventar records: 32
-    events with data out of 135 total flood events., Observed deaths directly caused
-    by disaster events from landslide (Landslide) events in Togo. DesInventar records:
-    1 events with data out of 6 total landslide events., Observed deaths directly
-    caused by disaster events from strong wind (Hurricane) events in Togo. DesInventar
-    records: 1 events with data out of 40 total strong wind events (1960-2013)., Observed
-    deaths directly caused by disaster events from wildfire (Fire, Forest fire) events
-    in Togo. DesInventar records: 13 events with data out of 197 total wildfire events
-    (2009-2009)., Observed educational facilities destroyed or affected from convective
-    storm (Thunderstorm) events in Togo. DesInventar records: 6 events with data out
-    of 9 total convective storm events (2011-2011)., Observed educational facilities
-    destroyed or affected from flood (Flood) events in Togo. DesInventar records:
-    15 events with data out of 135 total flood events., Observed educational facilities
-    destroyed or affected from strong wind (Hurricane) events in Togo. DesInventar
-    records: 14 events with data out of 40 total strong wind events (1960-2013).,
-    Observed educational facilities destroyed or affected from strong wind (Storm)
-    events in Togo. DesInventar records: 1 events with data out of 4 total strong
-    wind events., Observed educational facilities destroyed or affected from wildfire
-    (Fire, Forest fire) events in Togo. DesInventar records: 9 events with data out
-    of 197 total wildfire events (2009-2009)., Observed health facilities destroyed
-    or affected from flood (Flood) events in Togo. DesInventar records: 2 events with
-    data out of 135 total flood events., Observed health facilities destroyed or affected
-    from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with
-    data out of 40 total strong wind events (1960-2013)., Observed hectares of crops/woods
-    destroyed or affected from flood (Flood) events in Togo. DesInventar records:
-    21 events with data out of 135 total flood events., Observed hectares of crops/woods
-    destroyed or affected from wildfire (Fire, Forest fire) events in Togo. DesInventar
-    records: 14 events with data out of 197 total wildfire events (2009-2009)., Observed
-    homes destroyed beyond habitability from convective storm (Thunderstorm) events
-    in Togo. DesInventar records: 2 events with data out of 9 total convective storm
-    events (2011-2011)., Observed homes destroyed beyond habitability from flood (Flood)
-    events in Togo. DesInventar records: 59 events with data out of 135 total flood
-    events., Observed homes destroyed beyond habitability from landslide (Landslide)
-    events in Togo. DesInventar records: 5 events with data out of 6 total landslide
-    events., Observed homes destroyed beyond habitability from strong wind (Hurricane)
-    events in Togo. DesInventar records: 5 events with data out of 40 total strong
-    wind events (1960-2013)., Observed homes destroyed beyond habitability from wildfire
-    (Fire, Forest fire) events in Togo. DesInventar records: 64 events with data out
-    of 197 total wildfire events (2009-2009)., Observed homes with non-structural
-    damage, still habitable from convective storm (Thunderstorm) events in Togo. DesInventar
-    records: 4 events with data out of 9 total convective storm events (2011-2011).,
-    Observed homes with non-structural damage, still habitable from flood (Flood)
-    events in Togo. DesInventar records: 54 events with data out of 135 total flood
-    events., Observed homes with non-structural damage, still habitable from landslide
-    (Landslide) events in Togo. DesInventar records: 5 events with data out of 6 total
-    landslide events., Observed homes with non-structural damage, still habitable
-    from strong wind (Hurricane) events in Togo. DesInventar records: 14 events with
-    data out of 40 total strong wind events (1960-2013)., Observed homes with non-structural
-    damage, still habitable from strong wind (Storm) events in Togo. DesInventar records:
-    1 events with data out of 4 total strong wind events., Observed homes with non-structural
-    damage, still habitable from wildfire (Fire, Forest fire) events in Togo. DesInventar
-    records: 50 events with data out of 197 total wildfire events (2009-2009)., Observed
-    livestock lost from flood (Flood) events in Togo. DesInventar records: 1 events
-    with data out of 135 total flood events., Observed livestock lost from strong
-    wind (Hurricane) events in Togo. DesInventar records: 1 events with data out of
-    40 total strong wind events (1960-2013)., Observed metres of transport networks
-    destroyed from flood (Flood) events in Togo. DesInventar records: 4 events with
-    data out of 135 total flood events., Observed persons indirectly affected (disruption
-    to services, commerce, work) from convective storm (Thunderstorm) events in Togo.
-    DesInventar records: 2 events with data out of 9 total convective storm events
-    (2011-2011)., Observed persons indirectly affected (disruption to services, commerce,
-    work) from flood (Flood) events in Togo. DesInventar records: 109 events with
-    data out of 135 total flood events., Observed persons indirectly affected (disruption
-    to services, commerce, work) from landslide (Landslide) events in Togo. DesInventar
-    records: 5 events with data out of 6 total landslide events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from strong wind
-    (Hurricane) events in Togo. DesInventar records: 20 events with data out of 40
-    total strong wind events (1960-2013)., Observed persons indirectly affected (disruption
-    to services, commerce, work) from strong wind (Storm) events in Togo. DesInventar
-    records: 4 events with data out of 4 total strong wind events., Observed persons
-    indirectly affected (disruption to services, commerce, work) from wildfire (Fire,
-    Forest fire) events in Togo. DesInventar records: 162 events with data out of
-    197 total wildfire events (2009-2009)., Observed persons injured or made sick
-    directly by disaster events from flood (Flood) events in Togo. DesInventar records:
-    22 events with data out of 135 total flood events., Observed persons injured or
-    made sick directly by disaster events from strong wind (Hurricane) events in Togo.
-    DesInventar records: 3 events with data out of 40 total strong wind events (1960-2013).,
-    Observed persons injured or made sick directly by disaster events from wildfire
-    (Fire, Forest fire) events in Togo. DesInventar records: 7 events with data out
-    of 197 total wildfire events (2009-2009)., Observed persons missing or unaccounted
-    for after disaster events from flood (Flood) events in Togo. DesInventar records:
-    2 events with data out of 135 total flood events., Observed persons permanently
-    relocated from homes from flood (Flood) events in Togo. DesInventar records: 32
-    events with data out of 135 total flood events., Observed persons permanently
-    relocated from homes from wildfire (Fire, Forest fire) events in Togo. DesInventar
-    records: 12 events with data out of 197 total wildfire events (2009-2009)., Observed
-    persons temporarily evacuated from homes or workplaces from flood (Flood) events
-    in Togo. DesInventar records: 11 events with data out of 135 total flood events.,
-    Observed persons temporarily evacuated from homes or workplaces from landslide
-    (Landslide) events in Togo. DesInventar records: 1 events with data out of 6 total
-    landslide events., Observed persons temporarily evacuated from homes or workplaces
-    from strong wind (Hurricane) events in Togo. DesInventar records: 1 events with
-    data out of 40 total strong wind events (1960-2013)., Observed persons temporarily
-    evacuated from homes or workplaces from wildfire (Fire, Forest fire) events in
-    Togo. DesInventar records: 4 events with data out of 197 total wildfire events
-    (2009-2009)., Observed persons whose goods/services suffered serious damage from
-    flood (Flood) events in Togo. DesInventar records: 16 events with data out of
-    135 total flood events., Observed persons whose goods/services suffered serious
-    damage from landslide (Landslide) events in Togo. DesInventar records: 5 events
-    with data out of 6 total landslide events., Observed persons whose goods/services
-    suffered serious damage from wildfire (Fire, Forest fire) events in Togo. DesInventar
-    records: 10 events with data out of 197 total wildfire events (2009-2009)., Observed
-    total economic losses in US Dollars from convective storm (Thunderstorm) events
-    in Togo. DesInventar records: 1 events with data out of 9 total convective storm
-    events (2011-2011)., Observed total economic losses in US Dollars from flood (Flood)
-    events in Togo. DesInventar records: 30 events with data out of 135 total flood
-    events., Observed total economic losses in US Dollars from strong wind (Hurricane)
-    events in Togo. DesInventar records: 7 events with data out of 40 total strong
-    wind events (1960-2013)., Observed total economic losses in US Dollars from strong
-    wind (Storm) events in Togo. DesInventar records: 2 events with data out of 4
-    total strong wind events., Observed total economic losses in US Dollars from wildfire
-    (Fire, Forest fire) events in Togo. DesInventar records: 74 events with data out
-    of 197 total wildfire events (2009-2009).'
+  description: 52 loss records across 5 hazard types
   dimension: ''
   exposure_id: ''
   hazard_analysis_type: ''
@@ -160,6 +45,168 @@ loss:
   impact_metric: ''
   impact_type: ''
   impact_unit: ''
+  loss_count: 52
+  loss_groups:
+  - count: 6
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from convective storm (Thunderstorm) events in Togo. DesInventar records: 2
+      events with data out of 9 total convective storm events (2011-2011).'
+    - 'Observed deaths directly caused by disaster events from convective storm (Thunderstorm)
+      events in Togo. DesInventar records: 1 events with data out of 9 total convective
+      storm events (2011-2011).'
+    - 'Observed educational facilities destroyed or affected from convective storm
+      (Thunderstorm) events in Togo. DesInventar records: 6 events with data out of
+      9 total convective storm events (2011-2011).'
+    - 'Observed homes with non-structural damage, still habitable from convective
+      storm (Thunderstorm) events in Togo. DesInventar records: 4 events with data
+      out of 9 total convective storm events (2011-2011).'
+    - 'Observed homes destroyed beyond habitability from convective storm (Thunderstorm)
+      events in Togo. DesInventar records: 2 events with data out of 9 total convective
+      storm events (2011-2011).'
+    - 'Observed total economic losses in US Dollars from convective storm (Thunderstorm)
+      events in Togo. DesInventar records: 1 events with data out of 9 total convective
+      storm events (2011-2011).'
+    hazard_type: convective_storm
+  - count: 15
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from flood (Flood) events in Togo. DesInventar records: 109 events with data
+      out of 135 total flood events.'
+    - 'Observed hectares of crops/woods destroyed or affected from flood (Flood) events
+      in Togo. DesInventar records: 21 events with data out of 135 total flood events.'
+    - 'Observed metres of transport networks destroyed from flood (Flood) events in
+      Togo. DesInventar records: 4 events with data out of 135 total flood events.'
+    - 'Observed deaths directly caused by disaster events from flood (Flood) events
+      in Togo. DesInventar records: 32 events with data out of 135 total flood events.'
+    - 'Observed educational facilities destroyed or affected from flood (Flood) events
+      in Togo. DesInventar records: 15 events with data out of 135 total flood events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from flood
+      (Flood) events in Togo. DesInventar records: 11 events with data out of 135
+      total flood events.'
+    - 'Observed health facilities destroyed or affected from flood (Flood) events
+      in Togo. DesInventar records: 2 events with data out of 135 total flood events.'
+    - 'Observed homes with non-structural damage, still habitable from flood (Flood)
+      events in Togo. DesInventar records: 54 events with data out of 135 total flood
+      events.'
+    - 'Observed homes destroyed beyond habitability from flood (Flood) events in Togo.
+      DesInventar records: 59 events with data out of 135 total flood events.'
+    - 'Observed persons injured or made sick directly by disaster events from flood
+      (Flood) events in Togo. DesInventar records: 22 events with data out of 135
+      total flood events.'
+    - 'Observed total economic losses in US Dollars from flood (Flood) events in Togo.
+      DesInventar records: 30 events with data out of 135 total flood events.'
+    - 'Observed livestock lost from flood (Flood) events in Togo. DesInventar records:
+      1 events with data out of 135 total flood events.'
+    - 'Observed persons missing or unaccounted for after disaster events from flood
+      (Flood) events in Togo. DesInventar records: 2 events with data out of 135 total
+      flood events.'
+    - 'Observed persons permanently relocated from homes from flood (Flood) events
+      in Togo. DesInventar records: 32 events with data out of 135 total flood events.'
+    - 'Observed persons whose goods/services suffered serious damage from flood (Flood)
+      events in Togo. DesInventar records: 16 events with data out of 135 total flood
+      events.'
+    hazard_type: flood
+  - count: 6
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from landslide (Landslide) events in Togo. DesInventar records: 5 events with
+      data out of 6 total landslide events.'
+    - 'Observed deaths directly caused by disaster events from landslide (Landslide)
+      events in Togo. DesInventar records: 1 events with data out of 6 total landslide
+      events.'
+    - 'Observed persons temporarily evacuated from homes or workplaces from landslide
+      (Landslide) events in Togo. DesInventar records: 1 events with data out of 6
+      total landslide events.'
+    - 'Observed homes with non-structural damage, still habitable from landslide (Landslide)
+      events in Togo. DesInventar records: 5 events with data out of 6 total landslide
+      events.'
+    - 'Observed homes destroyed beyond habitability from landslide (Landslide) events
+      in Togo. DesInventar records: 5 events with data out of 6 total landslide events.'
+    - 'Observed persons whose goods/services suffered serious damage from landslide
+      (Landslide) events in Togo. DesInventar records: 5 events with data out of 6
+      total landslide events.'
+    hazard_type: landslide
+  - count: 14
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (Storm) events in Togo. DesInventar records: 4 events with
+      data out of 4 total strong wind events.'
+    - 'Observed educational facilities destroyed or affected from strong wind (Storm)
+      events in Togo. DesInventar records: 1 events with data out of 4 total strong
+      wind events.'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (Storm) events in Togo. DesInventar records: 1 events with data out of 4 total
+      strong wind events.'
+    - 'Observed total economic losses in US Dollars from strong wind (Storm) events
+      in Togo. DesInventar records: 2 events with data out of 4 total strong wind
+      events.'
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from strong wind (Hurricane) events in Togo. DesInventar records: 20 events
+      with data out of 40 total strong wind events (1960-2013).'
+    - 'Observed deaths directly caused by disaster events from strong wind (Hurricane)
+      events in Togo. DesInventar records: 1 events with data out of 40 total strong
+      wind events (1960-2013).'
+    - 'Observed educational facilities destroyed or affected from strong wind (Hurricane)
+      events in Togo. DesInventar records: 14 events with data out of 40 total strong
+      wind events (1960-2013).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from strong
+      wind (Hurricane) events in Togo. DesInventar records: 1 events with data out
+      of 40 total strong wind events (1960-2013).'
+    - 'Observed health facilities destroyed or affected from strong wind (Hurricane)
+      events in Togo. DesInventar records: 1 events with data out of 40 total strong
+      wind events (1960-2013).'
+    - 'Observed homes with non-structural damage, still habitable from strong wind
+      (Hurricane) events in Togo. DesInventar records: 14 events with data out of
+      40 total strong wind events (1960-2013).'
+    - 'Observed homes destroyed beyond habitability from strong wind (Hurricane) events
+      in Togo. DesInventar records: 5 events with data out of 40 total strong wind
+      events (1960-2013).'
+    - 'Observed persons injured or made sick directly by disaster events from strong
+      wind (Hurricane) events in Togo. DesInventar records: 3 events with data out
+      of 40 total strong wind events (1960-2013).'
+    - 'Observed total economic losses in US Dollars from strong wind (Hurricane) events
+      in Togo. DesInventar records: 7 events with data out of 40 total strong wind
+      events (1960-2013).'
+    - 'Observed livestock lost from strong wind (Hurricane) events in Togo. DesInventar
+      records: 1 events with data out of 40 total strong wind events (1960-2013).'
+    hazard_type: strong_wind
+  - count: 11
+    descriptions:
+    - 'Observed persons indirectly affected (disruption to services, commerce, work)
+      from wildfire (Fire, Forest fire) events in Togo. DesInventar records: 162 events
+      with data out of 197 total wildfire events (2009-2009).'
+    - 'Observed hectares of crops/woods destroyed or affected from wildfire (Fire,
+      Forest fire) events in Togo. DesInventar records: 14 events with data out of
+      197 total wildfire events (2009-2009).'
+    - 'Observed deaths directly caused by disaster events from wildfire (Fire, Forest
+      fire) events in Togo. DesInventar records: 13 events with data out of 197 total
+      wildfire events (2009-2009).'
+    - 'Observed educational facilities destroyed or affected from wildfire (Fire,
+      Forest fire) events in Togo. DesInventar records: 9 events with data out of
+      197 total wildfire events (2009-2009).'
+    - 'Observed persons temporarily evacuated from homes or workplaces from wildfire
+      (Fire, Forest fire) events in Togo. DesInventar records: 4 events with data
+      out of 197 total wildfire events (2009-2009).'
+    - 'Observed homes with non-structural damage, still habitable from wildfire (Fire,
+      Forest fire) events in Togo. DesInventar records: 50 events with data out of
+      197 total wildfire events (2009-2009).'
+    - 'Observed homes destroyed beyond habitability from wildfire (Fire, Forest fire)
+      events in Togo. DesInventar records: 64 events with data out of 197 total wildfire
+      events (2009-2009).'
+    - 'Observed persons injured or made sick directly by disaster events from wildfire
+      (Fire, Forest fire) events in Togo. DesInventar records: 7 events with data
+      out of 197 total wildfire events (2009-2009).'
+    - 'Observed total economic losses in US Dollars from wildfire (Fire, Forest fire)
+      events in Togo. DesInventar records: 74 events with data out of 197 total wildfire
+      events (2009-2009).'
+    - 'Observed persons permanently relocated from homes from wildfire (Fire, Forest
+      fire) events in Togo. DesInventar records: 12 events with data out of 197 total
+      wildfire events (2009-2009).'
+    - 'Observed persons whose goods/services suffered serious damage from wildfire
+      (Fire, Forest fire) events in Togo. DesInventar records: 10 events with data
+      out of 197 total wildfire events (2009-2009).'
+    hazard_type: wildfire
   type: ''
   vulnerability_id: ''
 project:

--- a/_datasets/rdls_vln-hdx_food_and_agriculture_caf_faostat_food_prices_for_central_african_republic.md
+++ b/_datasets/rdls_vln-hdx_food_and_agriculture_caf_faostat_food_prices_for_central_african_republic.md
@@ -29,7 +29,7 @@ exposure:
   taxonomy: null
 extra_attributions: []
 hazard: null
-license: CC-BY-IGO-3.0
+license: Creative Commons Attribution for Intergovernmental Organisations (CC BY-IGO)
 loss: null
 project: null
 publisher:

--- a/_includes/display/hazard_type.html
+++ b/_includes/display/hazard_type.html
@@ -13,3 +13,4 @@
             {{ site.data.rdl-hazard_type[code] }}
         {% endif %}
     </td>
+</tr>

--- a/_includes/display/loss_groups.html
+++ b/_includes/display/loss_groups.html
@@ -1,5 +1,5 @@
 <tr>
-  <th>{{ include.field.label }}</th>
+  <th>Loss Records Detail</th>
   <td>
     {% for group in include.value %}
       {% capture ht_code %}{{ group.hazard_type }}{% endcapture %}

--- a/_includes/display/loss_groups.html
+++ b/_includes/display/loss_groups.html
@@ -1,0 +1,20 @@
+<tr>
+  <th>{{ include.field.label }}</th>
+  <td>
+    {% for group in include.value %}
+      {% capture ht_code %}{{ group.hazard_type }}{% endcapture %}
+      {% assign ht_label = site.data.rdl-hazard_type[ht_code] | default: ht_code %}
+      <details class="loss-group">
+        <summary class="loss-group-summary">
+          {{ ht_label }}
+          <span class="badge">{{ group.count }}</span>
+        </summary>
+        <ul class="loss-group-descriptions">
+          {% for desc in group.descriptions %}
+            <li>{{ desc }}</li>
+          {% endfor %}
+        </ul>
+      </details>
+    {% endfor %}
+  </td>
+</tr>

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -36,7 +36,6 @@ layout: default
               <p x-ref="description" class="desc-text">{{ page.description }}</p>
               <button x-show="$refs.description.scrollHeight > $refs.description.clientHeight" class="desc-toggle" @click="open = ! open" x-text="open ? 'Show less' : 'Show more'"></button>
             </div>
-
             <!-- Quick Info Cards -->
             <div class="quick-info">
               {% if page.creator.name %}
@@ -166,6 +165,18 @@ layout: default
               {% endif %}
               {% endif %}
               {% endfor %}
+<<<<<<< HEAD
+=======
+              {% if rdt == "loss" and page.loss.loss_groups %}
+              {% include display/loss_groups.html value=page.loss.loss_groups %}
+              {% endif %}
+              {% if rdt == "loss" and page.loss.loss_count %}
+              <tr>
+                <th>Total Loss Records</th>
+                <td>{{ page.loss.loss_count }}</td>
+              </tr>
+              {% endif %}
+>>>>>>> f2109d8 (Remove schema changes, render loss_groups directly from layout)
             </table>
           </div>
           {% endfor %}
@@ -231,7 +242,23 @@ layout: default
             </div>
           </div>
 
+<<<<<<< HEAD
           {% include display/spatial_extent_map.html %}
+=======
+          <!-- Spatial Extent -->
+          {% if page.spatial.countries %}
+          <div class="sidebar-card">
+            <h4>Spatial Extent</h4>
+            <div style="margin-top: 8px; font-size: 11px; color: #6b7280;">
+              {% if page.spatial.countries.size > 1 %}
+                {{ page.spatial.countries | join: ", " }}
+              {% else %}
+                {{ page.spatial.countries | first }}
+              {% endif %}
+            </div>
+          </div>
+          {% endif %}
+>>>>>>> f2109d8 (Remove schema changes, render loss_groups directly from layout)
 
           <!-- Dataset Info Summary -->
           <div class="sidebar-card">
@@ -275,4 +302,7 @@ layout: default
     </div>
   </div>
 </div>
+<<<<<<< HEAD
 
+=======
+>>>>>>> f2109d8 (Remove schema changes, render loss_groups directly from layout)

--- a/css/modern-theme.css
+++ b/css/modern-theme.css
@@ -1376,3 +1376,80 @@ body {
 .desc-toggle:hover {
   text-decoration: underline;
 }
+
+/* ====================================
+   18. Loss Record Groups - Collapsible
+   ==================================== */
+.loss-group {
+  margin-bottom: 6px;
+  border: 1px solid #dee2e6;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.loss-group[open] {
+  border-color: #adb5bd;
+}
+
+.loss-group-summary {
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 13px;
+  background-color: #f8f9fa;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background-color 0.15s;
+}
+
+.loss-group-summary::-webkit-details-marker {
+  display: none;
+}
+
+.loss-group-summary::before {
+  content: "\25B6";
+  font-size: 9px;
+  color: #6c757d;
+  transition: transform 0.15s;
+}
+
+.loss-group[open] > .loss-group-summary::before {
+  transform: rotate(90deg);
+}
+
+.loss-group-summary:hover {
+  background-color: #e9ecef;
+}
+
+.loss-group-summary .badge {
+  margin-left: auto;
+  font-weight: 500;
+  font-size: 11px;
+  background-color: #495057;
+  color: #fff;
+  padding: 2px 7px;
+  border-radius: 10px;
+  min-width: 20px;
+  text-align: center;
+}
+
+.loss-group-descriptions {
+  margin: 0;
+  padding: 8px 14px 10px 32px;
+  font-size: 13px;
+  background-color: #fff;
+  border-top: 1px solid #dee2e6;
+  list-style: disc;
+}
+
+.loss-group-descriptions li {
+  margin-bottom: 4px;
+  line-height: 1.5;
+  color: #343a40;
+}
+
+.loss-group-descriptions li:last-child {
+  margin-bottom: 0;
+}

--- a/python/mappers.py
+++ b/python/mappers.py
@@ -118,11 +118,16 @@ def make_loss(loss):
         "vulnerability_id": [],
     }
 
+    # Group descriptions by hazard type for collapsible display
+    groups = {}
+
     for l in loss.get("losses", []):
+        ht = l.get("hazard_type", "")
+
         if "dimension" in l.get("cost", {}):
             props_to_summarize["dimension"].append(l["cost"]["dimension"])
-        if "hazard_type" in l:
-            props_to_summarize["hazard_type"].append(l["hazard_type"])
+        if ht:
+            props_to_summarize["hazard_type"].append(ht)
         if "approach" in l:
             props_to_summarize["approach"].append(l["approach"])
         if "base_data_type" in l.get("impact", {}):
@@ -130,7 +135,10 @@ def make_loss(loss):
         if "category" in l:
             props_to_summarize["category"].append(l["category"])
         if "description" in l:
-            props_to_summarize["description"].append(l["description"])
+            desc = l["description"]
+            props_to_summarize["description"].append(desc)
+            if ht and desc:
+                groups.setdefault(ht, []).append(desc)
         if "exposure_id" in l:
             props_to_summarize["exposure_id"].append(l["exposure_id"])
         if "hazard_analysis_type" in l:
@@ -150,13 +158,34 @@ def make_loss(loss):
         if "vulnerability_id" in l:
             props_to_summarize["vulnerability_id"].append(l["vulnerability_id"])
 
-    return {
+    # Build loss_groups: array of {hazard_type, count, descriptions}
+    loss_groups = [
+        {"hazard_type": ht, "count": len(descs), "descriptions": descs}
+        for ht, descs in sorted(groups.items())
+    ]
+
+    total_losses = len(loss.get("losses", []))
+    unique_hazards = len(set(props_to_summarize["hazard_type"]))
+
+    # For large datasets, replace concatenated descriptions with a summary
+    if total_losses > 5 and props_to_summarize["description"]:
+        description_str = (
+            f"{total_losses} loss records across "
+            f"{unique_hazards} hazard type"
+            f"{'s' if unique_hazards != 1 else ''}"
+        )
+    else:
+        description_str = ", ".join(
+            sorted(set(props_to_summarize["description"]))
+        )
+
+    result = {
         "dimension": ", ".join(sorted(set(props_to_summarize["dimension"]))),
         "hazard_type": ", ".join(sorted(set(props_to_summarize["hazard_type"]))),
         "approach": ", ".join(sorted(set(props_to_summarize["approach"]))),
         "base_data_type": ", ".join(sorted(set(props_to_summarize["base_data_type"]))),
         "category": ", ".join(sorted(set(props_to_summarize["category"]))),
-        "description": ", ".join(sorted(set(props_to_summarize["description"]))),
+        "description": description_str,
         "exposure_id": ", ".join(sorted(set(props_to_summarize["exposure_id"]))),
         "hazard_analysis_type": ", ".join(
             sorted(set(props_to_summarize["hazard_analysis_type"]))
@@ -171,6 +200,14 @@ def make_loss(loss):
             sorted(set(props_to_summarize["vulnerability_id"]))
         ),
     }
+
+    # Add structured fields when there are grouped descriptions
+    if loss_groups:
+        result["loss_groups"] = loss_groups
+    if total_losses > 0:
+        result["loss_count"] = total_losses
+
+    return result
 
 
 # v0.2 specific mappers


### PR DESCRIPTION
This PR contains:
- Revision of DesInventar markdown's dataset long description in single paragraphs, which replace into shorter description and grouping based on `hazard_type`
- Proposal for  https://github.com/GFDRR/rdl-jkan/issues/115