### PR TITLE
Fix text overflow in dataset template (#139)

### DIFF
--- a/css/modern-theme.css
+++ b/css/modern-theme.css
@@ -927,6 +927,7 @@ body {
   width: 100%;
   border-collapse: collapse;
   margin-top: 16px;
+  table-layout: fixed;
 }
 
 .data-table th {
@@ -947,6 +948,8 @@ body {
   font-size: 14px;
   color: #374151;
   border-bottom: 1px solid var(--color-border);
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .data-table tr:last-child td,


### PR DESCRIPTION
<img width="713" height="868" alt="Screenshot 2026-03-30 at 1 53 57 PM" src="https://github.com/user-attachments/assets/fb543e68-58f2-4783-b35d-3668fa60cd55" />

resolves #139